### PR TITLE
Revert "NIO-881, accessing class level logger through class method"

### DIFF
--- a/nio/modules/proxy.py
+++ b/nio/modules/proxy.py
@@ -66,7 +66,7 @@ class ModuleProxy(object):
     proxied = False
     _impl_class = None
     _unproxied_methods = defaultdict(dict)
-    logger = None
+    logger = get_nio_logger('ModuleProxy')
 
     def __init__(self, *args, **kwargs):
         """ Handling the instantiation of a ModuleProxy
@@ -109,7 +109,7 @@ class ModuleProxy(object):
                 continue
 
             interface_member = getattr(cls, name, None)
-            cls.get_logger().debug("Proxying member {0} from {1}".format(
+            cls.logger.debug("Proxying member {0} from {1}".format(
                 name, class_to_proxy.__name__))
             # Save a reference to the original member to replace during unproxy
             cls._unproxied_methods[cls.__name__][name] = interface_member
@@ -153,19 +153,3 @@ class ModuleProxy(object):
         """
         return not name.startswith('__') and \
             (isfunction(member) or ismethod(member) or not isroutine(member))
-
-    @classmethod
-    def get_logger(cls):
-        """ Get class level logger
-
-        If no logger has been created for class, a new logger is instantiated
-        and a reference is saved for future access.
-
-        Returns:
-            logger (NIOLoggerAdapter) A NIO logger adapter instance
-
-        """
-        if cls.logger is None:
-            cls.logger = get_nio_logger("ModuleProxy")
-
-        return cls.logger

--- a/nio/util/scheduler/scheduler.py
+++ b/nio/util/scheduler/scheduler.py
@@ -14,16 +14,7 @@ class Scheduler(object):
     _sched_resolution = 0.1
 
     @classmethod
-    def get_logger(cls):
-        """ Get class level logger
-
-        If no logger has been created for class, a new logger is instantiated
-        and a reference is saved for future access.
-
-        Returns:
-            logger (NIOLoggerAdapter) A NIO logger adapter instance
-
-        """
+    def _get_logger(cls):
         if cls.logger is None:
             cls.logger = get_nio_logger("NIOScheduler")
         return cls.logger
@@ -72,7 +63,7 @@ class Scheduler(object):
             None
 
         """
-        cls.get_logger().debug("Un-scheduling %s" % job)
+        cls._get_logger().debug("Un-scheduling %s" % job)
         cls._scheduler_thread.scheduler.cancel(job)
 
     @classmethod
@@ -85,10 +76,10 @@ class Scheduler(object):
     def start(cls):
         try:
             if cls._scheduler_thread is None:
-                cls.get_logger().info("Starting custom Scheduler")
+                cls._get_logger().info("Starting custom Scheduler")
                 cls._scheduler_thread = SchedulerThread(SchedulerHelper(
                     resolution=cls._sched_resolution,
                     min_delta=cls._sched_min_delta))
                 cls._scheduler_thread.start()
         except Exception:  # pragma: no cover (exception from ap)
-            cls.get_logger().exception("Scheduler failed to start")
+            cls._get_logger().exception("Scheduler failed to start")


### PR DESCRIPTION
Reverts nioinnovation/nio#13

On second thought, we should get rid of these `get_logger` calls all over the place. The only place we might want some local caching is in the scheduler since the logger can potentially get hit frequently. To do that, we should just create a locally scoped variable inside the loop method.
