### PR TITLE
NIO-949: After discussion with mdodge, decision was made to handle 20…

### DIFF
--- a/nio/modules/web/handlers/rest.py
+++ b/nio/modules/web/handlers/rest.py
@@ -85,7 +85,10 @@ class RESTHandler(WebHandler):
         raise NotImplementedError()
 
     def on_options(self, request, response):
-        """ Allows the client to respond to OPTIONS requests
+        """ Options request handler, respond 200 by default
+
+        We respond 200 by default for default CORS response. You are allowed
+        to override with your own implementation.
 
         Args:
             request: web request
@@ -95,4 +98,6 @@ class RESTHandler(WebHandler):
             Web result
 
         """
-        raise NotImplementedError()
+
+        response.set_status(200)
+        response.set_body("")


### PR DESCRIPTION
NIO-949: After discussion with @mattdodge, decision was made to handle 200 CORS by default in the framework and allow end user to override as desired.
