### PR TITLE
NIO-962, moving yielding behaviour to jump_ahead method, replacing sl…

### DIFF
--- a/nio/testing/modules/scheduler/tests/test_jump_ahead.py
+++ b/nio/testing/modules/scheduler/tests/test_jump_ahead.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-from time import sleep
 
 from nio.testing.test_case import NIOTestCase
 from nio.testing.modules.scheduler.job import JumpAheadJob
@@ -35,12 +34,10 @@ class TestJumpAheadJobs(NIOTestCase):
 
         # After 2 seconds, still not called
         job.jump_ahead(2)
-        sleep(0.05)
         self.assertEqual(self.times_called, 0)
 
         # After 4 more seconds (6 total), should be called once
         job.jump_ahead(4)
-        sleep(0.05)
         self.assertEqual(self.times_called, 1)
 
     def test_jump_repeatable(self):
@@ -56,12 +53,10 @@ class TestJumpAheadJobs(NIOTestCase):
 
         # After 6 seconds, called once
         job.jump_ahead(6)
-        sleep(0.05)
         self.assertEqual(self.times_called, 1)
 
         # After 15 more seconds (21 total), should be called 4 times
         job.jump_ahead(15)
-        sleep(0.05)
         self.assertEqual(self.times_called, 4)
 
     def test_cant_jump_backwards(self):

--- a/nio/util/scheduler/tests/test_job.py
+++ b/nio/util/scheduler/tests/test_job.py
@@ -40,23 +40,18 @@ class TestJob(NIOTestCase):
         self.job = Job(self.dummy.foo, timedelta(seconds=1), True)
         # jump forward in time a little more than 3 seconds
         self.job.jump_ahead(3.1)
-        # Let the scheduler loop hit once more
-        sleep(0.05)
         self.assertEqual(self.dummy.foo_called, 3)
 
     def test_run_with_args(self):
         self.job = Job(self.dummy.foo, timedelta(seconds=1), False, 2)
         # jump forward in time a little more than 1 second
         self.job.jump_ahead(1.1)
-        sleep(0.05)
         self.assertEqual(self.dummy.foo_called, 2)
 
     def test_run_with_kwargs(self):
         self.job = Job(self.dummy.foo, timedelta(seconds=1), False, add=3)
         # jump forward in time a little more than 1 second
         self.job.jump_ahead(1.1)
-        # Let the scheduler loop hit once more
-        sleep(0.05)
         self.assertEqual(self.dummy.foo_called, 3)
 
     def test_cancel_job(self):
@@ -65,6 +60,4 @@ class TestJob(NIOTestCase):
         self.job.cancel()
         # jump forward in time
         self.job.jump_ahead(2.5)
-        # Let the scheduler loop hit once more
-        sleep(0.05)
         self.assertEqual(self.dummy.foo_called, 0)

--- a/nio/util/scheduler/tests/test_scheduler_cleanup.py
+++ b/nio/util/scheduler/tests/test_scheduler_cleanup.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-from time import sleep
 from threading import RLock
 
 from nio.testing.modules.scheduler.scheduler import JumpAheadScheduler
@@ -29,8 +28,6 @@ class TestSchedulerCleanUp(NIOTestCase):
         self.assertEqual(len(scheduler._queue), num_tasks + 2)
         # jump forward in time
         repeatable_job.jump_ahead(0.2)
-        # allow yielding to scheduler
-        sleep(0.05)
         with scheduler._events_lock:
             self.assertEqual(len(scheduler._events), 2)
             self.assertIn(longer_job._job, scheduler._events)
@@ -40,8 +37,6 @@ class TestSchedulerCleanUp(NIOTestCase):
         # jump in time again, now longer_job must be gone since it was set to
         # execute at 0.3 seconds
         repeatable_job.jump_ahead(0.4)
-        # allow yielding to scheduler
-        sleep(0.05)
         with scheduler._events_lock:
             self.assertEqual(len(scheduler._events), 1)
             # and must only remain, the repeatable job
@@ -76,8 +71,6 @@ class TestSchedulerCleanUp(NIOTestCase):
 
         # jump forward in time (give ample time for jobs to be cancelled)
         jobs[0].jump_ahead(num_jobs/10)
-        # allow yielding to scheduler
-        sleep(0.05)
 
         # verify that nothing remains
         with scheduler._events_lock:

--- a/nio/util/scheduler/tests/test_two_jobs.py
+++ b/nio/util/scheduler/tests/test_two_jobs.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-from time import sleep
 from nio.modules.scheduler.job import Job
 from nio.testing.test_case import NIOTestCase
 
@@ -27,8 +26,6 @@ class TestScheduler(NIOTestCase):
         self.job2 = Job(dummy.foo2, timedelta(milliseconds=100), False)
         # simulate a jump forward in time
         self.job1.jump_ahead(0.8)
-        # yield to scheduler
-        sleep(0.05)
         self.assertEqual(dummy.foo1_called, True)
         self.assertEqual(dummy.foo2_called, True)
 
@@ -42,7 +39,5 @@ class TestScheduler(NIOTestCase):
         self.job1 = Job(dummy.foo1, timedelta(milliseconds=500), False)
         # simulate a jump forward in time
         self.job1.jump_ahead(0.8)
-        # yield to scheduler
-        sleep(0.05)
         self.assertEqual(dummy.foo1_called, True)
         self.assertEqual(dummy.foo2_called, True)


### PR DESCRIPTION
…eeps with event.wait for a more responsive scheduler allowing wait/sleep to be interrupted
