### PR TITLE
Log Exception Info on Failed Retry

### DIFF
--- a/nio/block/mixins/retry/retry.py
+++ b/nio/block/mixins/retry/retry.py
@@ -141,7 +141,7 @@ class Retry(object):
             except Exception as exc:
                 self.logger.warning(
                     "Retryable execution on method {} failed".format(
-                        execute_method_name, exc_info=True))
+                        execute_method_name), exc_info=True)
                 self._backoff_strategy.request_failed(exc)
                 should_retry = self._backoff_strategy.should_retry()
                 if not should_retry:


### PR DESCRIPTION
Looks like exc_info was passed erroneously to format instead of the warning logger