### PR TITLE
Record.msg hashable fix for cache handler

### DIFF
--- a/nio/util/logging/handlers/publisher/cache.py
+++ b/nio/util/logging/handlers/publisher/cache.py
@@ -39,7 +39,7 @@ class LogCache(object):
 
         # determine key, which includes a hashed msg, and attempt to get record
         key = "{}-{}-{}".format(record.filename, record.lineno,
-                                hash(record.msg))
+                                hash(str(record.msg)))
         # determine if item with same message is present
         if self._cache.get(key):
             return True

--- a/nio/util/logging/handlers/publisher/tests/test_cache.py
+++ b/nio/util/logging/handlers/publisher/tests/test_cache.py
@@ -56,3 +56,25 @@ class TestCache(NIOTestCase):
 
         log_cache.process_record(record2)
         self.assertEqual(log_cache._cache.add.call_count, 2)
+
+    def test_cache_key_behavior(self):
+        """ Asserts that record messages can be any object with a __str__ 
+        implementation, which is always hashable
+        """
+        log_cache = LogCache(0.1)
+
+        # two unhashable types for record.msg
+        record1 = get_log_record_same_line({})
+        record2 = get_log_record_same_line([])
+
+        # process two dicts
+        result1 = log_cache.process_record(record1)
+        result2 = log_cache.process_record(record1)
+        self.assertEqual(result1, False)
+        self.assertEqual(result2, True)
+
+        # process two lists
+        result1 = log_cache.process_record(record2)
+        result2 = log_cache.process_record(record2)
+        self.assertEqual(result1, False)
+        self.assertEqual(result2, True)


### PR DESCRIPTION
If one wishes to log a mutable object such as a dict inside of a block, the cache handler returns an error of the type:

```
[2017-08-09 14:43:03.575] NIO [ERROR] [Test Publisher.Test Log] Failed to log signal
Traceback (most recent call last):
  File "/nio/project/blocks/logger/logger_block.py", line 54, in _log_signals_sequentially
    log_func(s.to_dict())
  File "/usr/local/lib/python3.5/logging/__init__.py", line 1620, in error
    self.log(ERROR, msg, *args, **kwargs)
  File "/usr/local/lib/python3.5/logging/__init__.py", line 1641, in log
    self.logger._log(level, msg, args, **kwargs)
  File "/usr/local/lib/python3.5/logging/__init__.py", line 1416, in _log
    self.handle(record)
  File "/usr/local/lib/python3.5/logging/__init__.py", line 1426, in handle
    self.callHandlers(record)
  File "/usr/local/lib/python3.5/logging/__init__.py", line 1488, in callHandlers
    hdlr.handle(record)
  File "/usr/local/lib/python3.5/logging/__init__.py", line 852, in handle
    rv = self.filter(record)
  File "/usr/local/lib/python3.5/logging/__init__.py", line 711, in filter
    result = f.filter(record)
  File "/usr/local/lib/python3.5/site-packages/nio/util/logging/handlers/publisher/cache_filter.py", line 32, in filter
    return not self._log_cache.process_record(record)
  File "/usr/local/lib/python3.5/site-packages/nio/util/logging/handlers/publisher/cache.py", line 42, in process_record
    hash(record.msg))
TypeError: unhashable type: 'dict'
```

Here a change is proposed to instead hash the str of the message, which will accept any object with a `__str__` implementation. 