### PR TITLE
PROD-757, Sending router diagnostic as a single signal to avoid dupli…

### DIFF
--- a/nio/router/base.py
+++ b/nio/router/base.py
@@ -342,8 +342,9 @@ class BlockRouter(Runner):
 
                     if self._diagnostics:
                         self._diagnostic_manager.on_signal_delivery(
-                            block._service_name, block.name(),
-                            receiver_data.block.name(), len(signals_to_send)
+                            block.name(),
+                            receiver_data.block.name(),
+                            len(signals_to_send)
                         )
 
                     self.deliver_signals(receiver_data, signals_to_send)

--- a/nio/router/context.py
+++ b/nio/router/context.py
@@ -4,7 +4,8 @@ class RouterContext(object):
 
     def __init__(self, execution, blocks, settings=None,
                  mgmt_signal_handler=None,
-                 instance_id=None):
+                 instance_id=None,
+                 service_name=None):
         """Initializes a router context.
 
         Args:
@@ -18,9 +19,11 @@ class RouterContext(object):
             mgmt_signal_handler (method): method to use to notify
                 management signals, receives signal as only parameter
             instance_id: Instance the service belongs to
+            service_name (str): service this router belongs to
         """
         self.execution = execution
         self.blocks = blocks
         self.settings = settings or {}
         self.mgmt_signal_handler = mgmt_signal_handler
         self.instance_id = instance_id
+        self.service_name = service_name

--- a/nio/service/base.py
+++ b/nio/service/base.py
@@ -197,7 +197,8 @@ class Service(PropertyHolder, CommandHolder, Runner):
                                        self._blocks,
                                        context.router_settings,
                                        context.mgmt_signal_handler,
-                                       context.instance_id)
+                                       context.instance_id,
+                                       self.name())
         self._block_router.do_configure(router_context)
         self.mgmt_signal_handler = context.mgmt_signal_handler
         self._blocks_async_start = context.blocks_async_start


### PR DESCRIPTION
The idea here is to avoid duplicate data, and send router diagnostic as a single signal since it was causing headaches later when wanting to make a single Product API call for a given router diagnostic