### PR TITLE
API-376, maintaining case sensitivity when serializing/deserializing a project

### DIFF
--- a/nio/project/serializers/file/serializer.py
+++ b/nio/project/serializers/file/serializer.py
@@ -162,6 +162,8 @@ class FileSerializer(ProjectSerializer):
 
         # create instance where settings will be stored and written from
         settings = RawConfigParser()
+        # keep case sensitivity
+        settings.optionxform = str
 
         # save special dict entries known to be saved as linked files
         serialized_entries = self._serialize_dict_entries(configuration)
@@ -293,6 +295,8 @@ class FileSerializer(ProjectSerializer):
 
         # read the contents of the conf file with the config parser
         settings = RawConfigParser()
+        # keep case sensitivity
+        settings.optionxform = str
         settings.read(nio_conf)
 
         # Populate our configuration dictionary

--- a/nio/project/serializers/file/tests/test_serialize.py
+++ b/nio/project/serializers/file/tests/test_serialize.py
@@ -111,7 +111,7 @@ class TestSerialize(NIOTestCase):
             ConfigurationEntity({"option1": "value1"})
         # option to be saved with a new value
         project1.configuration["security"] = \
-            ConfigurationEntity({"option3": "value3"})
+            ConfigurationEntity({"OPTION3": "value3"})
 
         # seralize configuration creating a conf file on disk
         serializer1 = FileSerializer(self.tmp_project_dir)
@@ -133,7 +133,7 @@ class TestSerialize(NIOTestCase):
             ConfigurationEntity({"option2": "value2"})
         # add an option that already exists in file
         project1.configuration["security"] = \
-            ConfigurationEntity({"option3": "new value3"})
+            ConfigurationEntity({"OPTION3": "new value3"})
         # serialize new project
         serializer1.serialize(project1)
 
@@ -150,10 +150,10 @@ class TestSerialize(NIOTestCase):
         self.assertEqual('value2',
                          project2.configuration["logging"].data["option2"])
         # assert that option3 contains the new value
-        self.assertIn("option3",
+        self.assertIn("OPTION3",
                       project2.configuration["security"].data)
         self.assertEqual('new value3',
-                         project2.configuration["security"].data["option3"])
+                         project2.configuration["security"].data["OPTION3"])
 
     def test_config_dict_entries(self):
         """ Asserts known dict entries are serialized as files


### PR DESCRIPTION
This is needed for file to redis conversion, I've found that env variables, as defined under [user_defined], need to keep the case sensitivity intact