### PR TITLE
NIO-1053, adding 'id' to block, making 'name' optional, having 'id' play former name-uniqueness role

### DIFF
--- a/nio/block/base.py
+++ b/nio/block/base.py
@@ -3,8 +3,6 @@
 A block contains modular functionality to be used inside of Services. To create
 a custom block, extend this Block class and override the appropriate methods.
 """
-from uuid import uuid4
-
 from nio.block.context import BlockContext
 from nio.block.terminals import Terminal, TerminalType, input, output, \
     DEFAULT_TERMINAL
@@ -50,7 +48,6 @@ class Base(PropertyHolder, CommandHolder, Runner):
 
         super().__init__(status_change_callback=status_change_callback)
 
-        self.id = uuid4().hex
         # store block type so that it gets serialized
         self.type = self.__class__.__name__
 
@@ -89,7 +86,7 @@ class Base(PropertyHolder, CommandHolder, Runner):
         # verify that block properties are valid
         self.validate()
 
-        self.logger = get_nio_logger(self.id())
+        self.logger = get_nio_logger(self.label(True))
         self.logger.setLevel(self.log_level())
         self._service_name = context.service_name
 
@@ -225,6 +222,19 @@ class Base(PropertyHolder, CommandHolder, Runner):
             bool: True if the output ID exists on this block
         """
         return output_id in [o.id for o in self.__class__.outputs()]
+
+    def label(self, include_id=False):
+        """ Provides a label to a block based on name and id properties
+        
+        Args:
+            include_id: whether id is to be included in label 
+        """
+        if self.name():
+            if include_id:
+                return "{}-{}".format(self.name(), self.id())
+            else:
+                return self.name()
+        return self.id()
 
 
 @input(DEFAULT_TERMINAL, default=True, label="default")

--- a/nio/block/base.py
+++ b/nio/block/base.py
@@ -86,7 +86,7 @@ class Base(PropertyHolder, CommandHolder, Runner):
         # verify that block properties are valid
         self.validate()
 
-        self.logger = get_nio_logger(self.label(True))
+        self.logger = get_nio_logger(self.label())
         self.logger.setLevel(self.log_level())
         self._service_name = context.service_name
 

--- a/nio/block/mixins/persistence/persistence.py
+++ b/nio/block/mixins/persistence/persistence.py
@@ -1,6 +1,6 @@
-from nio.properties import TimeDeltaProperty, BoolProperty
 from nio.modules.persistence import Persistence as PersistenceModule
 from nio.modules.scheduler import Job
+from nio.properties import TimeDeltaProperty, BoolProperty
 
 
 class Persistence(object):
@@ -39,14 +39,14 @@ class Persistence(object):
     def _load(self):
         """ Load the values from persistence
 
-        Item is loaded from persistence using block name, once item
+        Item is loaded from persistence using block id, once item
         is loaded, all persisted values are examined against loaded
         item, if it exists, such value is then set as an attribute
         in the block instance
         """
         self.logger.debug("Loading from persistence")
         # load whole item from persistence
-        item = self._persistence.load(self.name(), default={})
+        item = self._persistence.load(self.id(), default={})
         for persisted_var in self.persisted_values():
             if persisted_var in item:
                 self.logger.debug("Loaded value {} for attribute {}".format(
@@ -62,12 +62,12 @@ class Persistence(object):
         # to be persisted into a dictionary
         item = {persisted_var: getattr(self, persisted_var)
                 for persisted_var in self.persisted_values()}
-        # save generated dictionary under block's name
-        self._persistence.save(item, self.name())
+        # save generated dictionary under block's id
+        self._persistence.save(item, self.id())
 
     def configure(self, context):
         super().configure(context)
-        # Create a persistence object using the block's name
+        # Create a persistence object using the block's id
         self._persistence = PersistenceModule()
         if self.load_from_persistence():
             self._load()

--- a/nio/block/mixins/persistence/persistence.py
+++ b/nio/block/mixins/persistence/persistence.py
@@ -46,7 +46,7 @@ class Persistence(object):
         """
         self.logger.debug("Loading from persistence")
         # load whole item from persistence
-        item = self._persistence.load(self.id(), default={})
+        item = self._persistence.load(self.label(include_id=True), default={})
         for persisted_var in self.persisted_values():
             if persisted_var in item:
                 self.logger.debug("Loaded value {} for attribute {}".format(
@@ -62,8 +62,8 @@ class Persistence(object):
         # to be persisted into a dictionary
         item = {persisted_var: getattr(self, persisted_var)
                 for persisted_var in self.persisted_values()}
-        # save generated dictionary under block's id
-        self._persistence.save(item, self.id())
+        # save generated dictionary under block's label
+        self._persistence.save(item, self.label(include_id=True))
 
     def configure(self, context):
         super().configure(context)

--- a/nio/block/mixins/persistence/persistence.py
+++ b/nio/block/mixins/persistence/persistence.py
@@ -46,7 +46,7 @@ class Persistence(object):
         """
         self.logger.debug("Loading from persistence")
         # load whole item from persistence
-        item = self._persistence.load(self.label(include_id=True), default={})
+        item = self._persistence.load(self.id(), default={})
         for persisted_var in self.persisted_values():
             if persisted_var in item:
                 self.logger.debug("Loaded value {} for attribute {}".format(
@@ -62,8 +62,8 @@ class Persistence(object):
         # to be persisted into a dictionary
         item = {persisted_var: getattr(self, persisted_var)
                 for persisted_var in self.persisted_values()}
-        # save generated dictionary under block's label
-        self._persistence.save(item, self.label(include_id=True))
+        # save generated dictionary under block's id
+        self._persistence.save(item, self.id())
 
     def configure(self, context):
         super().configure(context)

--- a/nio/block/mixins/persistence/tests/test_persistence.py
+++ b/nio/block/mixins/persistence/tests/test_persistence.py
@@ -34,7 +34,7 @@ class TestPersistence(NIOBlockTestCase):
         # in block's constructor
         block.stop()
 
-        item = block._persistence.load(block.label(include_id=True))
+        item = block._persistence.load(block.id())
         # Make sure the right data was saved
         self.assertEqual(len(item), 2)
         self.assertEqual(item['_to_be_saved'], 'value')
@@ -50,7 +50,7 @@ class TestPersistence(NIOBlockTestCase):
         block._persistence.save({
             "_to_be_saved": "saved value 1",
             "_to_be_saved_again": "saved value 2"
-        }, block.label(include_id=True))
+        }, block.id())
         # Force the load now - it happened in configure too, but we hadn't
         # overwritten the values yet
         block._load()
@@ -110,11 +110,11 @@ class TestPersistence(NIOBlockTestCase):
 
         block = PersistingBlock()
         block.id = 'test_block'
-        # save data under block label
+        # save data under block id
         PersistenceModule().save(
             {'_to_be_saved': 3,
              '_to_be_saved_again': 4},
-            block.label(include_id=True))
+            block.id())
 
         # make block load from persistence
         self.configure_block(block,

--- a/nio/block/mixins/persistence/tests/test_persistence.py
+++ b/nio/block/mixins/persistence/tests/test_persistence.py
@@ -28,13 +28,13 @@ class TestPersistence(NIOBlockTestCase):
     def test_saves_properly(self):
         """ Tests that the mixin saves the right values """
         block = PersistingBlock()
-        self.configure_block(block, {})
+        self.configure_block(block, {"id": "test_block"})
         block.start()
         # Stop the block to initiate the save using values specified
         # in block's constructor
         block.stop()
 
-        item = block._persistence.load(block.id())
+        item = block._persistence.load(block.label(include_id=True))
         # Make sure the right data was saved
         self.assertEqual(len(item), 2)
         self.assertEqual(item['_to_be_saved'], 'value')
@@ -44,12 +44,13 @@ class TestPersistence(NIOBlockTestCase):
         """ Tests that the mixin loads into the right values """
         block = PersistingBlock()
         self.configure_block(block, {
-            'load_from_persistence': True
+            'load_from_persistence': True,
+            'id': 'test_block'
         })
         block._persistence.save({
             "_to_be_saved": "saved value 1",
             "_to_be_saved_again": "saved value 2"
-        }, block.id())
+        }, block.label(include_id=True))
         # Force the load now - it happened in configure too, but we hadn't
         # overwritten the values yet
         block._load()
@@ -108,15 +109,17 @@ class TestPersistence(NIOBlockTestCase):
         """
 
         block = PersistingBlock()
-        # save data under block id
+        block.id = 'test_block'
+        # save data under block label
         PersistenceModule().save(
             {'_to_be_saved': 3,
              '_to_be_saved_again': 4},
-            block.id())
+            block.label(include_id=True))
 
         # make block load from persistence
         self.configure_block(block,
-                             {'load_from_persistence': True
+                             {'id': 'test_block',
+                              'load_from_persistence': True
                               })
         # assert that data matches what was persisted outside of block
         self.assertEqual(block._to_be_saved, 3)

--- a/nio/block/tests/test_block_base.py
+++ b/nio/block/tests/test_block_base.py
@@ -1,15 +1,16 @@
 from unittest.mock import patch, Mock
+
 from nio.block.base import Block
-from nio.block.terminator_block import TerminatorBlock
-from nio.block.generator_block import GeneratorBlock
 from nio.block.context import BlockContext
+from nio.block.generator_block import GeneratorBlock
 from nio.block.terminals import DEFAULT_TERMINAL
+from nio.block.terminator_block import TerminatorBlock
 from nio.properties.exceptions import AllowNoneViolation
-from nio.signal.base import Signal
 from nio.router.base import BlockRouter
 from nio.router.context import RouterContext
-from nio.testing.test_case import NIOTestCaseNoModules
+from nio.signal.base import Signal
 from nio.signal.status import BlockStatusSignal
+from nio.testing.test_case import NIOTestCaseNoModules
 from nio.util.runner import RunnerStatus
 
 
@@ -20,8 +21,7 @@ class TestBaseBlock(NIOTestCaseNoModules):
         blk = Block()
         blk.configure(BlockContext(
             BlockRouter(),
-            {"name": "BlockName", "log_level": "WARNING"},
-            {}))
+            {"name": "BlockName", "log_level": "WARNING"}))
         # Make sure the name property got set properly
         self.assertEqual(blk.name(), "BlockName")
 
@@ -36,8 +36,8 @@ class TestBaseBlock(NIOTestCaseNoModules):
             # The context's block router needs to be a BlockRouter
             Block().configure(BlockContext(JustAnObject, {}))
         with self.assertRaises(AllowNoneViolation):
-            # Block needs a name
-            Block().configure(BlockContext(BlockRouter(), {"name": None}))
+            # Block needs an id
+            Block().configure(BlockContext(BlockRouter(), {"id": None}))
         with self.assertRaises(TypeError):
             # Wrong types (like log_level not being corrrect) raise TypeError
             Block().configure(BlockContext(BlockRouter(), {"name": "BlockName",

--- a/nio/block/tests/test_block_base.py
+++ b/nio/block/tests/test_block_base.py
@@ -21,9 +21,9 @@ class TestBaseBlock(NIOTestCaseNoModules):
         blk = Block()
         blk.configure(BlockContext(
             BlockRouter(),
-            {"name": "BlockName", "log_level": "WARNING"}))
+            {"id": "BlockId", "log_level": "WARNING"}))
         # Make sure the name property got set properly
-        self.assertEqual(blk.name(), "BlockName")
+        self.assertEqual(blk.id(), "BlockId")
 
     def test_invalid_configure(self):
         """Make sure a block is configured with valid information"""
@@ -39,8 +39,8 @@ class TestBaseBlock(NIOTestCaseNoModules):
             # Block needs an id
             Block().configure(BlockContext(BlockRouter(), {"id": None}))
         with self.assertRaises(TypeError):
-            # Wrong types (like log_level not being corrrect) raise TypeError
-            Block().configure(BlockContext(BlockRouter(), {"name": "BlockName",
+            # Wrong types (like log_level not being correct) raise TypeError
+            Block().configure(BlockContext(BlockRouter(), {"id": "BlockId",
                                                            "log_level": 42}))
 
     def test_notify_management_signal(self):
@@ -48,8 +48,7 @@ class TestBaseBlock(NIOTestCaseNoModules):
         blk = Block()
         blk.configure(BlockContext(
             BlockRouter(),
-            {"name": "BlockName", "log_level": "WARNING"},
-            {}))
+            {"id": "BlockId", "log_level": "WARNING"}))
         my_sig = Signal({"key": "val"})
         with patch.object(blk, '_block_router') as router_patch:
             blk.notify_management_signal(my_sig)
@@ -67,8 +66,7 @@ class TestBaseBlock(NIOTestCaseNoModules):
         block_router.configure(router_context)
         blk.configure(BlockContext(
             block_router,
-            {"name": "BlockName", "log_level": "WARNING"},
-            {}))
+            {"id": "BlockId", "log_level": "WARNING"}))
         my_sig = Signal({"key": "val"})
         blk.notify_management_signal(my_sig)
         service_mgmt_signal_handler.assert_called_once_with(my_sig)
@@ -80,7 +78,7 @@ class TestBaseBlock(NIOTestCaseNoModules):
         service_name = 'service1'
         blk.configure(BlockContext(
             BlockRouter(),
-            {"name": block_name},
+            {"id": block_name},
             service_name=service_name))
 
         my_sigs = [Signal({"key": "val"})]
@@ -171,7 +169,8 @@ class TestBaseBlock(NIOTestCaseNoModules):
         service_name = 'service1'
         blk.configure(BlockContext(
             BlockRouter(),
-            {"name": block_name},
+            {"id": "block_id",
+             "name": block_name},
             service_name=service_name))
 
         warning = BlockStatusSignal(

--- a/nio/block/tests/test_block_config.py
+++ b/nio/block/tests/test_block_config.py
@@ -27,8 +27,7 @@ class TestBlockConfig(NIOTestCase):
     def setUp(self):
         # Build some sample configuration (don't actually load anything)
         super().setUp()
-        self._config = {"name": "dummy_block"}
-        self._config[CONFIG_KEY] = CONFIG_VAL
+        self._config = {"id": "dummy_block", CONFIG_KEY: CONFIG_VAL}
 
     def test_load_config(self):
         """Test that a configuration can get loaded into the block"""
@@ -42,7 +41,7 @@ class TestBlockConfig(NIOTestCase):
         """Test that with no configuration the attribute exists, but not set"""
         block = DummyBlock()
         block.configure(BlockContext(BlockRouter(),
-                                     dict()))
+                                     {"id": "BlockId"}))
 
         self.assertTrue(hasattr(block, CONFIG_KEY))
         self.assertEqual(getattr(block, CONFIG_KEY)(), None)

--- a/nio/block/tests/test_block_config.py
+++ b/nio/block/tests/test_block_config.py
@@ -1,7 +1,7 @@
 from nio.block.base import Block
 from nio.block.context import BlockContext
-from nio.router.base import BlockRouter
 from nio.properties import StringProperty
+from nio.router.base import BlockRouter
 from nio.testing.test_case import NIOTestCase
 
 CONFIG_KEY = "attr_1"
@@ -11,7 +11,6 @@ CONFIG_VAL = "attr_1_val"
 class DummyBlock(Block):
     # Create a dummy block with my configurable attribute
     attr_1 = StringProperty(title="attr_1", allow_none=True)
-    # For this test only, allow name to be None
     name = StringProperty(title="name", allow_none=True)
 
 

--- a/nio/project/project.py
+++ b/nio/project/project.py
@@ -16,7 +16,7 @@ class Project(object):
     def __init__(self):
         super().__init__()
         # A project has configured blocks. It is stored as a dictionary
-        # where the key is the block name and the value is a Block instance
+        # where the key is the block id and the value is a Block instance
         self.blocks = dict()
 
         # A project has configured services. It is stored as a dictionary

--- a/nio/properties/holder.py
+++ b/nio/properties/holder.py
@@ -193,14 +193,14 @@ class PropertyHolder(object):
         return getattr(cls, class_attribute)
 
     def _process_and_log_version(self, class_properties, properties, logger):
-        name = properties.get("name", "")
+        id = properties.get("id", "")
         try:
             self._handle_versions(class_properties, properties)
         except OlderThanMinVersion as e:
             if logger:
                 logger.warning('Instance {0} version: {1} is older than'
                                ' minimum: {2}'.format
-                               (name, e.instance_version, e.min_version))
+                               (id, e.instance_version, e.min_version))
         except (NoClassVersion, NoInstanceVersion):
             # pass on classes with no version info.
             # pass on instances with no version info in their config.

--- a/nio/properties/holder.py
+++ b/nio/properties/holder.py
@@ -193,7 +193,8 @@ class PropertyHolder(object):
         return getattr(cls, class_attribute)
 
     def _process_and_log_version(self, class_properties, properties, logger):
-        id = properties.get("id", "")
+        # get either 'id' or 'name' property of this holder
+        id = properties.get("id", properties.get("name", ""))
         try:
             self._handle_versions(class_properties, properties)
         except OlderThanMinVersion as e:

--- a/nio/router/base.py
+++ b/nio/router/base.py
@@ -58,7 +58,7 @@ class BlockReceiverData(object):
             return True
         else:
             raise InvalidProcessSignalsSignature(
-                "Block {} signature is invalid".format(block.id()))
+                "Block {} signature is invalid".format(block.label(True)))
 
 
 class BlockRouter(Runner):
@@ -337,7 +337,7 @@ class BlockRouter(Runner):
                     self.logger.debug(
                         "Routing {} signals from {} to {}".format(
                             len(signals_to_send),
-                            block.id(),
+                            block.label(True),
                             receiver_data.block.id()))
 
                     if self._diagnostics:

--- a/nio/router/base.py
+++ b/nio/router/base.py
@@ -312,13 +312,13 @@ class BlockRouter(Runner):
                     self.logger.debug(
                         "Block '{}' has status 'error'. Not delivering "
                         "signals from '{}'...".format(
-                            receiver_data.block.id(), block.id()))
+                            receiver_data.block.label(), block.label()))
                     continue
                 elif receiver_data.block.status.is_set(RunnerStatus.warning):
                     self.logger.debug(
                         "Block '{}' has status 'warning'. Delivering signals"
                         " anyway from '{}...".format(
-                            receiver_data.block.id(), block.id()))
+                            receiver_data.block.label(), block.label()))
 
                 # We only send signals if the receiver's output matches
                 # the output that these signals were notified on
@@ -331,14 +331,14 @@ class BlockRouter(Runner):
                         signals_to_send = signals
                         self.logger.info("'deepcopy' operation failed while "
                                          "sending signals originating from "
-                                         "block: {}".format(block.id()),
+                                         "block: {}".format(block.label()),
                                          exc_info=True)
 
                     self.logger.debug(
                         "Routing {} signals from {} to {}".format(
                             len(signals_to_send),
                             block.label(True),
-                            receiver_data.block.id()))
+                            receiver_data.block.label()))
 
                     if self._diagnostics:
                         self._diagnostic_manager.on_signal_delivery(
@@ -354,15 +354,15 @@ class BlockRouter(Runner):
         elif self.status.is_set(RunnerStatus.stopped):
             self.logger.warning("Block Router is stopped, discarding signal"
                                 " notification from block: {}".
-                                format(block.id()))
+                                format(block.label()))
         elif self.status.is_set(RunnerStatus.stopping):
             self.logger.debug("Block Router is stopping, discarding signal"
                               " notification from block: {}".
-                              format(block.id()))
+                              format(block.label()))
         else:
             self.logger.warning("Block Router is not started, status is: {}, "
                                 "discarding signal notification from block: {}"
-                                .format(self.status, block.id()))
+                                .format(self.status, block.label()))
             raise BlockRouterNotStarted()
 
     def deliver_signals(self, block_receiver, signals):
@@ -405,4 +405,4 @@ class BlockRouter(Runner):
         except:
             self.status.add(RunnerStatus.error)
             self.logger.exception("{}.process_signals failed".
-                                  format(block_receiver.block.id()))
+                                  format(block_receiver.block.label()))

--- a/nio/router/context.py
+++ b/nio/router/context.py
@@ -12,7 +12,7 @@ class RouterContext(object):
             execution (list):  execution list as defined by BaseService
                 execution property
             blocks (dict):  dictionary of blocks that looks like this:
-                block_name: block instance format
+                [block_id]: [block instance]
             settings (dict): router settings, these can include
                 "clone_signals" and/or any other settings depending on router
                 being used

--- a/nio/router/tests/test_base_diagnostic.py
+++ b/nio/router/tests/test_base_diagnostic.py
@@ -12,10 +12,6 @@ from nio.testing.test_case import NIOTestCase
 
 class SenderBlock(Block):
 
-    def __init__(self):
-        super().__init__()
-        self.name = self.__class__.__name__.lower()
-
     def process_signals(self, signals, input_id=DEFAULT_TERMINAL):
         self.notify_signals(signals)
 
@@ -24,7 +20,6 @@ class ReceiverBlock(Block):
 
     def __init__(self):
         super().__init__()
-        self.name = self.__class__.__name__.lower()
         self.signal_cache = None
 
     def process_signals(self, signals, input_id=DEFAULT_TERMINAL):
@@ -36,8 +31,8 @@ class ReceiverBlock(Block):
 
 class BlockExecutionTest(BlockExecution):
 
-    def __init__(self, name, receivers):
-        self.name = name
+    def __init__(self, id, receivers):
+        self.id = id
         self.receivers = receivers
 
 
@@ -59,10 +54,12 @@ class TestBaseDiagnostics(NIOTestCase):
         receiver_block.configure(context)
 
         # create context initialization data
-        blocks = dict(receiverblock=receiver_block,
-                      senderblock=sender_block)
-        execution = [BlockExecutionTest(name="senderblock",
-                                        receivers=["receiverblock"])]
+        receiver_block_id = receiver_block.id()
+        sender_block_id = sender_block.id()
+        blocks = {receiver_block_id: receiver_block,
+                  sender_block_id:sender_block}
+        execution = [BlockExecutionTest(id=sender_block.id(),
+                                        receivers=[receiver_block.id()])]
 
         signal_handler = Mock()
         router_context = RouterContext(execution, blocks,
@@ -103,9 +100,9 @@ class TestBaseDiagnostics(NIOTestCase):
         self.assertEqual(len(signal.blocks_data), 1)
         block_data = signal.blocks_data[0]
         self.assertEqual(block_data["source_type"], sender_block.type())
-        self.assertEqual(block_data["source"], sender_block.name())
+        self.assertEqual(block_data["source"], sender_block.id())
         self.assertEqual(block_data["target_type"], receiver_block.type())
-        self.assertEqual(block_data["target"], receiver_block.name())
+        self.assertEqual(block_data["target"], receiver_block.id())
         self.assertEqual(block_data["count"], 1)
         # assert data was cleared after a diagnostic delivery
         self.assertEqual(

--- a/nio/router/tests/test_base_diagnostic.py
+++ b/nio/router/tests/test_base_diagnostic.py
@@ -12,6 +12,10 @@ from nio.testing.test_case import NIOTestCase
 
 class SenderBlock(Block):
 
+    def __init__(self):
+        super().__init__()
+        self.id = self.__class__.__name__.lower()
+
     def process_signals(self, signals, input_id=DEFAULT_TERMINAL):
         self.notify_signals(signals)
 
@@ -20,6 +24,7 @@ class ReceiverBlock(Block):
 
     def __init__(self):
         super().__init__()
+        self.id = self.__class__.__name__.lower()
         self.signal_cache = None
 
     def process_signals(self, signals, input_id=DEFAULT_TERMINAL):

--- a/nio/router/tests/test_cloning.py
+++ b/nio/router/tests/test_cloning.py
@@ -12,6 +12,10 @@ from nio.testing.test_case import NIOTestCase
 
 class SenderBlock(Block):
 
+    def __init__(self):
+        super().__init__()
+        self.id = self.__class__.__name__.lower()
+
     def process_signals(self, signals, input_id=DEFAULT_TERMINAL):
         self.notify_signals(signals)
 
@@ -20,6 +24,7 @@ class ReceiverBlock1(Block):
 
     def __init__(self):
         super().__init__()
+        self.id = self.__class__.__name__.lower()
         self.signal_cache = None
 
     def process_signals(self, signals, input_id=DEFAULT_TERMINAL):
@@ -36,6 +41,7 @@ class ReceiverBlock2(Block):
 
     def __init__(self):
         super().__init__()
+        self.id = self.__class__.__name__.lower()
         self.signal_cache = None
 
     def process_signals(self, signals, input_id=DEFAULT_TERMINAL):

--- a/nio/router/tests/test_cloning.py
+++ b/nio/router/tests/test_cloning.py
@@ -12,10 +12,6 @@ from nio.testing.test_case import NIOTestCase
 
 class SenderBlock(Block):
 
-    def __init__(self):
-        super().__init__()
-        self.name = self.__class__.__name__.lower()
-
     def process_signals(self, signals, input_id=DEFAULT_TERMINAL):
         self.notify_signals(signals)
 
@@ -24,7 +20,6 @@ class ReceiverBlock1(Block):
 
     def __init__(self):
         super().__init__()
-        self.name = self.__class__.__name__.lower()
         self.signal_cache = None
 
     def process_signals(self, signals, input_id=DEFAULT_TERMINAL):
@@ -41,7 +36,6 @@ class ReceiverBlock2(Block):
 
     def __init__(self):
         super().__init__()
-        self.name = self.__class__.__name__.lower()
         self.signal_cache = None
 
     def process_signals(self, signals, input_id=DEFAULT_TERMINAL):
@@ -55,8 +49,8 @@ class ReceiverBlock2(Block):
 
 class BlockExecutionTest(BlockExecution):
 
-    def __init__(self, name, receivers):
-        self.name = name
+    def __init__(self, id, receivers):
+        self.id = id
         self.receivers = receivers
 
 
@@ -77,12 +71,14 @@ class TestCloningSignals(NIOTestCase):
         receiver_block2.configure(context)
 
         # create context initialization data
-        blocks = dict(receiverblock1=receiver_block1,
-                      receiverblock2=receiver_block2,
-                      senderblock=sender_block)
-        execution = [BlockExecutionTest(name="senderblock",
-                                        receivers=["receiverblock1",
-                                                   "receiverblock2"])]
+        blocks = {
+            receiver_block1.id(): receiver_block1,
+            receiver_block2.id(): receiver_block2,
+            sender_block.id(): sender_block
+        }
+        execution = [BlockExecutionTest(id=sender_block.id(),
+                                        receivers=[receiver_block1.id(),
+                                                   receiver_block2.id()])]
 
         router_context = RouterContext(execution, blocks,
                                        {"clone_signals": True})
@@ -142,12 +138,14 @@ class TestCloningSignals(NIOTestCase):
         receiver_block2.configure(context)
 
         # create context initialization data
-        blocks = dict(receiverblock1=receiver_block1,
-                      receiverblock2=receiver_block2,
-                      senderblock=sender_block)
-        execution = [BlockExecutionTest(name="senderblock",
-                                        receivers=["receiverblock1",
-                                                   "receiverblock2"])]
+        blocks = {
+            receiver_block1.id(): receiver_block1,
+            receiver_block2.id(): receiver_block2,
+            sender_block.id(): sender_block
+        }
+        execution = [BlockExecutionTest(id=sender_block.id(),
+                                        receivers=[receiver_block1.id(),
+                                                   receiver_block2.id()])]
 
         router_context = RouterContext(execution, blocks)
 

--- a/nio/router/tests/test_input_output.py
+++ b/nio/router/tests/test_input_output.py
@@ -90,6 +90,10 @@ from nio.testing.test_case import NIOTestCase
 
 class Sim(Block):
 
+    def __init__(self):
+        super().__init__()
+        self.id = self.__class__.__name__.lower()
+
     def process_signals(self, signals, input_id=DEFAULT_TERMINAL):
         self.notify_signals(signals)
 
@@ -98,6 +102,7 @@ class Log1(Block):
 
     def __init__(self):
         super().__init__()
+        self.id = self.__class__.__name__.lower()
         self.signal_cache = []
 
     def process_signals(self, signals, input_id=DEFAULT_TERMINAL):
@@ -108,6 +113,7 @@ class Log2(Block):
 
     def __init__(self):
         super().__init__()
+        self.id = self.__class__.__name__.lower()
         self.signal_cache = []
 
     # Don't have to define an input_id
@@ -117,6 +123,10 @@ class Log2(Block):
 
 class InvalidProcessSignals(Block):
 
+    def __init__(self):
+        super().__init__()
+        self.id = self.__class__.__name__.lower()
+
     # This process signals signature is invalid and should throw an exception
     def process_signals(self, signals, input_id, what_am_i):
         pass
@@ -125,14 +135,20 @@ class InvalidProcessSignals(Block):
 @output(0)
 @output(1)
 class Two_Outputs(Block):
-    pass
+
+    def __init__(self):
+        super().__init__()
+        self.id = self.__class__.__name__.lower()
 
 
 @output(0)
 @output(1)
 @output(2)
 class Three_Outputs(Block):
-    pass
+
+    def __init__(self):
+        super().__init__()
+        self.id = self.__class__.__name__.lower()
 
 
 @input(0)
@@ -140,6 +156,7 @@ class Three_Outputs(Block):
 class State(Block):
     def __init__(self):
         super().__init__()
+        self.id = self.__class__.__name__.lower()
         self.signal_cache_input0 = []
         self.signal_cache_input1 = []
 

--- a/nio/router/tests/test_input_output.py
+++ b/nio/router/tests/test_input_output.py
@@ -90,10 +90,6 @@ from nio.testing.test_case import NIOTestCase
 
 class Sim(Block):
 
-    def __init__(self):
-        super().__init__()
-        self.name = self.__class__.__name__.lower()
-
     def process_signals(self, signals, input_id=DEFAULT_TERMINAL):
         self.notify_signals(signals)
 
@@ -102,7 +98,6 @@ class Log1(Block):
 
     def __init__(self):
         super().__init__()
-        self.name = self.__class__.__name__.lower()
         self.signal_cache = []
 
     def process_signals(self, signals, input_id=DEFAULT_TERMINAL):
@@ -113,7 +108,6 @@ class Log2(Block):
 
     def __init__(self):
         super().__init__()
-        self.name = self.__class__.__name__.lower()
         self.signal_cache = []
 
     # Don't have to define an input_id
@@ -123,10 +117,6 @@ class Log2(Block):
 
 class InvalidProcessSignals(Block):
 
-    def __init__(self):
-        super().__init__()
-        self.name = self.__class__.__name__.lower()
-
     # This process signals signature is invalid and should throw an exception
     def process_signals(self, signals, input_id, what_am_i):
         pass
@@ -135,29 +125,21 @@ class InvalidProcessSignals(Block):
 @output(0)
 @output(1)
 class Two_Outputs(Block):
-
-    def __init__(self):
-        super().__init__()
-        self.name = self.__class__.__name__.lower()
+    pass
 
 
 @output(0)
 @output(1)
 @output(2)
 class Three_Outputs(Block):
-
-    def __init__(self):
-        super().__init__()
-        self.name = self.__class__.__name__.lower()
+    pass
 
 
 @input(0)
 @input(1)
 class State(Block):
-
     def __init__(self):
         super().__init__()
-        self.name = self.__class__.__name__.lower()
         self.signal_cache_input0 = []
         self.signal_cache_input1 = []
 
@@ -169,9 +151,8 @@ class State(Block):
 
 
 class BlockExecutionTest(BlockExecution):
-
-    def __init__(self, name, receivers):
-        self.name = name
+    def __init__(self, id, receivers):
+        self.id = id
         self.receivers = receivers
 
 
@@ -190,16 +171,18 @@ class TestInputOutput(NIOTestCase):
         log2.configure(context)
 
         # create context initialization data
-        blocks = dict(log1=log1,
-                      log2=log2,
-                      two_outputs=two_outputs)
+        blocks = {
+            log1.id(): log1,
+            log2.id(): log2,
+            two_outputs.id(): two_outputs
+        }
 
         input_id1 = 0
         input_id2 = 1
         execution = [
-            BlockExecutionTest(name="two_outputs",
-                               receivers={0: ["log1"],
-                                          1: ["log2"]})]
+            BlockExecutionTest(id=two_outputs.id(),
+                               receivers={0: [log1.id()],
+                                          1: [log2.id()]})]
 
         router_context = RouterContext(execution, blocks,
                                        settings={"clone_signals": False})
@@ -251,11 +234,12 @@ class TestInputOutput(NIOTestCase):
         log1.configure(context)
 
         # create context initialization data
-        blocks = dict(log1=log1,
-                      two_outputs=two_outputs)
-
+        blocks = {
+            log1.id(): log1,
+            two_outputs.id(): two_outputs
+        }
         execution = [
-            BlockExecutionTest(name="two_outputs",
+            BlockExecutionTest(id=two_outputs.id(),
                                receivers=[])]
 
         router_context = RouterContext(execution, blocks,
@@ -279,12 +263,13 @@ class TestInputOutput(NIOTestCase):
         log1.configure(context)
 
         # create context initialization data
-        blocks = dict(log1=log1,
-                      two_outputs=two_outputs)
-
+        blocks = {
+            log1.id(): log1,
+            two_outputs.id(): two_outputs
+        }
         execution = [
-            BlockExecutionTest(name="two_outputs",
-                               receivers=["log1"])]
+            BlockExecutionTest(id=two_outputs.id(),
+                               receivers=[log1.id()])]
 
         router_context = RouterContext(execution, blocks,
                                        settings={"clone_signals": False})
@@ -310,19 +295,20 @@ class TestInputOutput(NIOTestCase):
         log2.configure(context)
 
         # create context initialization data
-        blocks = dict(three_outputs=three_outputs,
-                      state=state,
-                      log1=log1,
-                      log2=log2)
-
+        blocks = {
+            log1.id(): log1,
+            log2.id(): log2,
+            state.id(): state,
+            three_outputs.id(): three_outputs
+        }
         input_id0 = 0
         input_id1 = 1
         input_id2 = 2
         execution = [BlockExecutionTest(
-            name="three_outputs",
-            receivers={0: [{"name": "state", "input": input_id0}, "log1"],
-                       1: [{"name": "state", "input": input_id1}],
-                       2: ["log2"]})]
+            id=three_outputs.id(),
+            receivers={0: [{"id": state.id(), "input": input_id0}, log1.id()],
+                       1: [{"id": state.id(), "input": input_id1}],
+                       2: [log2.id()]})]
 
         router_context = RouterContext(execution, blocks,
                                        settings={"clone_signals": False})

--- a/nio/router/tests/test_input_output_validations.py
+++ b/nio/router/tests/test_input_output_validations.py
@@ -10,7 +10,10 @@ from nio.testing.test_case import NIOTestCase
 
 
 class OutputBlock(Block):
-    pass
+
+    def __init__(self):
+        super().__init__()
+        self.id = self.__class__.__name__.lower()
 
 
 @output("first", default=True)
@@ -27,6 +30,7 @@ class InputBlock(Block):
 
     def __init__(self):
         super().__init__()
+        self.id = self.__class__.__name__.lower()
         self.signal_cache = []
 
     def process_signals(self, signals, input_id=DEFAULT_TERMINAL):

--- a/nio/router/tests/test_notify_management_signals.py
+++ b/nio/router/tests/test_notify_management_signals.py
@@ -33,14 +33,14 @@ class ReceiverBlock(Block):
 # In some of the tests, one of the recevier blocks (the notifier) will notify
 # some management signals to the router
 blocks = [{"type": SenderBlock,
-           "properties": {'name': 'senderblock'}},
+           "properties": {'id': 'senderblock'}},
           {"type": ReceiverBlock,
-           "properties": {'name': 'receiverblock'}},
+           "properties": {'id': 'receiverblock'}},
           {"type": ReceiverBlock,
-           "properties": {'name': 'notifierblock'}}]
+           "properties": {'id': 'notifierblock'}}]
 
 execution = [BlockExecution()]
-execution[0].name = "senderblock"
+execution[0].id = "senderblock"
 execution[0].receivers = ["receiverblock", "notifierblock"]
 
 properties = {"name": "ServiceTestInstance",

--- a/nio/router/tests/test_pool_executor.py
+++ b/nio/router/tests/test_pool_executor.py
@@ -9,6 +9,10 @@ from nio.testing.test_case import NIOTestCase
 
 class SenderBlock(Block):
 
+    def __init__(self):
+        super().__init__()
+        self.id = self.__class__.__name__.lower()
+
     def process_signals(self, signals, input_id=DEFAULT_TERMINAL):
         self.notify_signals(signals)
 
@@ -17,6 +21,7 @@ class ReceiverBlock(Block):
 
     def __init__(self):
         super().__init__()
+        self.id = self.__class__.__name__.lower()
         self.signal_cache = None
 
     def process_signals(self, signals, input_id=DEFAULT_TERMINAL):

--- a/nio/router/tests/test_pool_executor.py
+++ b/nio/router/tests/test_pool_executor.py
@@ -9,10 +9,6 @@ from nio.testing.test_case import NIOTestCase
 
 class SenderBlock(Block):
 
-    def __init__(self):
-        super().__init__()
-        self.name = self.__class__.__name__.lower()
-
     def process_signals(self, signals, input_id=DEFAULT_TERMINAL):
         self.notify_signals(signals)
 
@@ -21,7 +17,6 @@ class ReceiverBlock(Block):
 
     def __init__(self):
         super().__init__()
-        self.name = self.__class__.__name__.lower()
         self.signal_cache = None
 
     def process_signals(self, signals, input_id=DEFAULT_TERMINAL):
@@ -33,8 +28,8 @@ class ReceiverBlock(Block):
 
 class BlockExecutionTest(BlockExecution):
 
-    def __init__(self, name, receivers):
-        self.name = name
+    def __init__(self, id, receivers):
+        self.id = id
         self.receivers = receivers
 
 
@@ -58,10 +53,12 @@ class TestBlockRouter(NIOTestCase):
         receiver_block.configure(context)
 
         # create context initialization data
-        blocks = dict(receiverblock=receiver_block,
-                      senderblock=sender_block)
-        execution = [BlockExecutionTest(name="senderblock",
-                                        receivers=["receiverblock"])]
+        blocks = {
+            receiver_block.id():receiver_block,
+            sender_block.id():sender_block
+        }
+        execution = [BlockExecutionTest(id=sender_block.id(),
+                                        receivers=[receiver_block.id()])]
 
         router_context = RouterContext(execution, blocks, {"max_workers": 3})
 

--- a/nio/router/tests/test_router.py
+++ b/nio/router/tests/test_router.py
@@ -96,10 +96,10 @@ class TestBaseRouter(NIOTestCase):
         router = BlockRouter()
         context = BlockContext(router, {})
         b1 = block_1()
-        b1.name = "b1"
+        b1.id = "b1"
         b1.configure(context)
         b2 = block_2()
-        b2.name = "b2"
+        b2.id = "b2"
         b2.configure(context)
 
         blocks = {
@@ -108,22 +108,22 @@ class TestBaseRouter(NIOTestCase):
         }
 
         b1_execution = BlockExecution()
-        b1_execution.name = "b1"
+        b1_execution.id = "b1"
 
         if block_1_output is None and block_2_input is None:
             # Both default terminals
-            # Just specify the name of the block for receiver
+            # Just specify the id of the block for receiver
             b1_execution.receivers = ["b2"]
         elif block_1_output is None and block_2_input is not None:
             # Default output, specified input
-            # Specify a dict for receiver containing input and block name
+            # Specify a dict for receiver containing input and block id
             b1_execution.receivers = [{
-                "name": "b2",
+                "id": "b2",
                 "input": block_2_input
             }]
         elif block_1_output is not None and block_2_input is None:
             # Specified output, default input
-            # Source block is a dict with output, receiver is block name
+            # Source block is a dict with output, receiver is block id
             b1_execution.receivers = {
                 block_1_output: ["b2"]
             }
@@ -132,7 +132,7 @@ class TestBaseRouter(NIOTestCase):
             # Source block is a dict with output, receiver is dict with input
             b1_execution.receivers = {
                 block_1_output: [{
-                    "name": "b2",
+                    "id": "b2",
                     "input": block_2_input
                 }]
             }
@@ -352,10 +352,10 @@ class TestBaseRouter(NIOTestCase):
         router = BlockRouter()
         context = BlockContext(router, {})
         source = SourceBlock()
-        source.name = "source"
+        source.id = "source"
         source.configure(context)
         dest = DestBlock()
-        dest.name = "dest"
+        dest.id = "dest"
         dest.configure(context)
 
         blocks = {
@@ -364,8 +364,8 @@ class TestBaseRouter(NIOTestCase):
         }
 
         source_execution = BlockExecution()
-        source_execution.name = "source"
-        # block receiver name is invalid, it expects a valid block name
+        source_execution.id = "source"
+        # block receiver id is invalid, it expects a valid block id
         source_execution.receivers = ["invalid"]
 
         router_context = RouterContext([source_execution], blocks)
@@ -384,10 +384,10 @@ class TestBaseRouter(NIOTestCase):
         router = BlockRouter()
         context = BlockContext(router, {})
         source = SourceBlock()
-        source.name = "source"
+        source.id = "source"
         source.configure(context)
         dest = DestBlock()
-        dest.name = "dest"
+        dest.id = "dest"
         dest.configure(context)
 
         blocks = {
@@ -396,7 +396,7 @@ class TestBaseRouter(NIOTestCase):
         }
 
         source_execution = BlockExecution()
-        source_execution.name = "source"
+        source_execution.id = "source"
         # make receivers format invalid
         source_execution.receivers = [{
             "input": DEFAULT_TERMINAL,
@@ -407,10 +407,10 @@ class TestBaseRouter(NIOTestCase):
         with self.assertRaises(KeyError):
             router.do_configure(router_context)
 
-        # make block name invalid to cause a MissingBlock
+        # make block id invalid to cause a MissingBlock
         source_execution.receivers = [{
             "input": DEFAULT_TERMINAL,
-            "name": "invalid"
+            "id": "invalid"
         }]
         router_context = RouterContext([source_execution], blocks)
         with self.assertRaises(MissingBlock):
@@ -505,15 +505,15 @@ class TestBaseRouter(NIOTestCase):
         router = BlockRouter()
         context = BlockContext(router, {})
         source = SourceBlock()
-        source.name = "source"
+        source.id = "source"
         source.configure(context)
 
         dest1 = DestBlock1()
-        dest1.name = "dest1"
+        dest1.id = "dest1"
         dest1.configure(context)
 
         dest2 = DestBlock2()
-        dest2.name = "dest2"
+        dest2.id = "dest2"
         dest2.configure(context)
 
         blocks = {
@@ -523,7 +523,7 @@ class TestBaseRouter(NIOTestCase):
         }
 
         source_execution = BlockExecution()
-        source_execution.name = "source"
+        source_execution.id = "source"
         source_execution.receivers = ["dest1", "dest2"]
 
         router_context = RouterContext([source_execution], blocks,

--- a/nio/router/tests/test_routers_on_exception.py
+++ b/nio/router/tests/test_routers_on_exception.py
@@ -13,11 +13,19 @@ from nio.util.runner import RunnerStatus
 
 class SenderBlock(Block):
 
+    def __init__(self):
+        super().__init__()
+        self.id = self.__class__.__name__.lower()
+
     def process_signals(self, signals, input_id=DEFAULT_TERMINAL):
         self.notify_signals(signals)
 
 
 class ExceptionThrowerReceiverBlock(Block):
+
+    def __init__(self):
+        super().__init__()
+        self.id = self.__class__.__name__.lower()
 
     def process_signals(self, signals, input_id=DEFAULT_TERMINAL):
         raise RuntimeError("Throwing exception")

--- a/nio/router/tests/test_routers_on_exception.py
+++ b/nio/router/tests/test_routers_on_exception.py
@@ -13,19 +13,11 @@ from nio.util.runner import RunnerStatus
 
 class SenderBlock(Block):
 
-    def __init__(self):
-        super().__init__()
-        self.name = self.__class__.__name__.lower()
-
     def process_signals(self, signals, input_id=DEFAULT_TERMINAL):
         self.notify_signals(signals)
 
 
 class ExceptionThrowerReceiverBlock(Block):
-
-    def __init__(self):
-        super().__init__()
-        self.name = self.__class__.__name__.lower()
 
     def process_signals(self, signals, input_id=DEFAULT_TERMINAL):
         raise RuntimeError("Throwing exception")
@@ -33,8 +25,8 @@ class ExceptionThrowerReceiverBlock(Block):
 
 class BlockExecutionTest(BlockExecution):
 
-    def __init__(self, name, receivers):
-        self.name = name
+    def __init__(self, id, receivers):
+        self.id = id
         self.receivers = receivers
 
 
@@ -51,10 +43,12 @@ class TestThreadedRouter(NIOTestCase):
         receiver_block.configure(context)
 
         # create context initialization data
-        blocks = dict(receiverblock=receiver_block,
-                      senderblock=sender_block)
-        execution = [BlockExecutionTest(name="senderblock",
-                                        receivers=["receiverblock"])]
+        blocks = {
+            receiver_block.id():receiver_block,
+            sender_block.id():sender_block
+        }
+        execution = [BlockExecutionTest(id=sender_block.id(),
+                                        receivers=[receiver_block.id()])]
 
         router_context = RouterContext(execution, blocks,
                                        {"check_signal_type": False})

--- a/nio/router/tests/test_signals_argument.py
+++ b/nio/router/tests/test_signals_argument.py
@@ -11,14 +11,21 @@ from nio.testing.test_case import NIOTestCase
 
 
 class SenderBlock(Block):
-    pass
+
+    def __init__(self):
+        super().__init__()
+        self.id = "sender_block"
 
 
 class ReceiverBlock(Block):
-    pass
+
+    def __init__(self):
+        super().__init__()
+        self.id = "receiver_block"
 
 
 class BlockExecutionTest(BlockExecution):
+
     def __init__(self, id, receivers):
         self.id = id
         self.receivers = receivers

--- a/nio/router/tests/test_signals_argument.py
+++ b/nio/router/tests/test_signals_argument.py
@@ -11,23 +11,16 @@ from nio.testing.test_case import NIOTestCase
 
 
 class SenderBlock(Block):
-
-    def __init__(self):
-        super().__init__()
-        self.name = "sender_block"
+    pass
 
 
 class ReceiverBlock(Block):
-
-    def __init__(self):
-        super().__init__()
-        self.name = "receiver_block"
+    pass
 
 
 class BlockExecutionTest(BlockExecution):
-
-    def __init__(self, name, receivers):
-        self.name = name
+    def __init__(self, id, receivers):
+        self.id = id
         self.receivers = receivers
 
 
@@ -41,10 +34,12 @@ class TestSignalsArgument(NIOTestCase):
         receiver_block = ReceiverBlock()
         block_router = BlockRouter()
         context = BlockContext(block_router, dict())
-        blocks = dict(receiver_block=receiver_block,
-                      sender_block=sender_block)
-        execution = [BlockExecutionTest(name="sender_block",
-                                        receivers=["receiver_block"])]
+        blocks = {
+            receiver_block.id():receiver_block,
+            sender_block.id():sender_block
+        }
+        execution = [BlockExecutionTest(id=sender_block.id(),
+                                        receivers=[receiver_block.id()])]
         router_context = RouterContext(execution, blocks)
         block_router.do_configure(router_context)
         block_router.do_start()
@@ -94,10 +89,12 @@ class TestSignalsArgument(NIOTestCase):
         receiver_block = ReceiverBlock()
         block_router = BlockRouter()
         context = BlockContext(block_router, dict())
-        blocks = dict(receiver_block=receiver_block,
-                      sender_block=sender_block)
-        execution = [BlockExecutionTest(name="sender_block",
-                                        receivers=["receiver_block"])]
+        blocks = {
+            receiver_block.id():receiver_block,
+            sender_block.id():sender_block
+        }
+        execution = [BlockExecutionTest(id=sender_block.id(),
+                                        receivers=[receiver_block.id()])]
         router_context = RouterContext(execution, blocks,
                                        {"check_signal_type": False})
         block_router.do_configure(router_context)

--- a/nio/router/tests/test_threaded_router.py
+++ b/nio/router/tests/test_threaded_router.py
@@ -12,6 +12,10 @@ from nio.testing.test_case import NIOTestCase
 
 class SenderBlock(Block):
 
+    def __init__(self):
+        super().__init__()
+        self.id = self.__class__.__name__.lower()
+
     def process_signals(self, signals):
         self.notify_signals(signals)
 
@@ -20,6 +24,7 @@ class ReceiverBlock(Block):
 
     def __init__(self):
         super().__init__()
+        self.id = self.__class__.__name__.lower()
         self.signal_received = Event()
 
     def process_signals(self, signals, input_id=DEFAULT_TERMINAL):

--- a/nio/router/tests/test_threaded_router.py
+++ b/nio/router/tests/test_threaded_router.py
@@ -12,10 +12,6 @@ from nio.testing.test_case import NIOTestCase
 
 class SenderBlock(Block):
 
-    def __init__(self):
-        super().__init__()
-        self.name = self.__class__.__name__.lower()
-
     def process_signals(self, signals):
         self.notify_signals(signals)
 
@@ -24,7 +20,6 @@ class ReceiverBlock(Block):
 
     def __init__(self):
         super().__init__()
-        self.name = self.__class__.__name__.lower()
         self.signal_received = Event()
 
     def process_signals(self, signals, input_id=DEFAULT_TERMINAL):
@@ -37,8 +32,8 @@ class ReceiverBlock(Block):
 
 class BlockExecutionTest(BlockExecution):
 
-    def __init__(self, name, receivers):
-        self.name = name
+    def __init__(self, id, receivers):
+        self.id = id
         self.receivers = receivers
 
 
@@ -59,10 +54,12 @@ class TestThreadedRouter(NIOTestCase):
         receiver_block.configure(context)
 
         # create context initialization data
-        blocks = dict(receiverblock=receiver_block,
-                      senderblock=sender_block)
-        execution = [BlockExecutionTest(name="senderblock",
-                                        receivers=["receiverblock"])]
+        blocks = {
+            receiver_block.id():receiver_block,
+            sender_block.id():sender_block
+        }
+        execution = [BlockExecutionTest(id=sender_block.id(),
+                                        receivers=[receiver_block.id()])]
 
         router_context = RouterContext(execution, blocks,
                                        {"check_signal_type": False})

--- a/nio/service/base.py
+++ b/nio/service/base.py
@@ -23,7 +23,7 @@ class BlockExecution(PropertyHolder):
     This information is parsed/used by the Router which is able then, based on
     the sending block, to forward signals to its receivers
     """
-    name = StringProperty(title="Name")
+    id = StringProperty(title="Id")
     receivers = Property(title="Receivers")
 
 
@@ -185,7 +185,7 @@ class Service(PropertyHolder, CommandHolder, Runner):
             block = self._create_and_configure_block(
                 block_definition['type'],
                 block_context)
-            self._blocks[block.name()] = block
+            self._blocks[block.id()] = block
 
         # populate router context and configure block router
         router_context = RouterContext(self.execution(),
@@ -253,6 +253,6 @@ class Service(PropertyHolder, CommandHolder, Runner):
     def full_status(self):
         """Returns service plus block statuses for each block in the service"""
         status = {"service": self.status.name}
-        for name in self._blocks:
-            status.update({name: self._blocks[name].status.name})
+        for id in self._blocks:
+            status.update({id: self._blocks[id].status.name})
         return status

--- a/nio/service/tests/test_service_base.py
+++ b/nio/service/tests/test_service_base.py
@@ -33,9 +33,9 @@ class TestBaseService(NIOTestCase):
             pass
 
         blocks = [{"type": Block1,
-                   "properties": {'name': 'block1'}},
+                   "properties": {'id': 'block1'}},
                   {"type": Block2,
-                   "properties": {'name': 'block2'}}]
+                   "properties": {'id': 'block2'}}]
 
         service.do_configure(ServiceContext(
             {"name": "ServiceName", "log_level": "WARNING"},
@@ -79,9 +79,9 @@ class TestBaseService(NIOTestCase):
         """
         service = Service()
         blocks = [{"type": Block,
-                   "properties": {}},
+                   "properties": {'id': 'block1'}},
                   {"type": Block,
-                   "properties": {}}]
+                   "properties": {'id': 'block2'}}]
         service.do_configure(ServiceContext(
             {"name": "ServiceName", "log_level": "WARNING"},
             blocks=blocks,
@@ -101,9 +101,9 @@ class TestBaseService(NIOTestCase):
 
         service = Service()
         blocks = [{"type": Block,
-                   "properties": {}},
+                   "properties": {'id': 'block1'}},
                   {"type": Block,
-                   "properties": {}}]
+                   "properties": {'id': 'block2'}}]
         service.do_configure(ServiceContext(
             {"name": "ServiceName", "log_level": "WARNING"},
             blocks=blocks,
@@ -123,9 +123,9 @@ class TestBaseService(NIOTestCase):
 
         service = Service()
         blocks = [{"type": Block,
-                   "properties": {}},
+                   "properties": {'id': 'block1'}},
                   {"type": Block,
-                   "properties": {}}]
+                   "properties": {'id': 'block2'}}]
         service.do_configure(ServiceContext(
             {"name": "ServiceName", "log_level": "WARNING"},
             blocks=blocks,

--- a/nio/service/tests/test_service_base.py
+++ b/nio/service/tests/test_service_base.py
@@ -46,23 +46,21 @@ class TestBaseService(NIOTestCase):
         ))
         # verify that statuses were updated
         status = service.full_status()
-        self.assertIn("service", status)
-        self.assertEqual(status["service"], "configured")
-        self.assertIn("block1", status)
-        self.assertEqual(status["block1"], "configured")
-        self.assertIn("block2", status)
-        self.assertEqual(status["block2"], "configured")
+        status_values = list(status.values())
+        self.assertEqual(len(status_values), 3)
+        self.assertEqual(status_values[0], "configured")
+        self.assertEqual(status_values[1], "configured")
+        self.assertEqual(status_values[2], "configured")
 
         service.do_start()
 
         # verify that statuses were updated
         status = service.full_status()
-        self.assertIn("service", status)
-        self.assertEqual(status["service"], "started")
-        self.assertIn("block1", status)
-        self.assertEqual(status["block1"], "started")
-        self.assertIn("block2", status)
-        self.assertEqual(status["block2"], "started")
+        status_values = list(status.values())
+        self.assertEqual(len(status_values), 3)
+        self.assertEqual(status_values[0], "started")
+        self.assertEqual(status_values[1], "started")
+        self.assertEqual(status_values[2], "started")
 
         self.assertEqual(len(service.blocks), 2)
 
@@ -70,23 +68,20 @@ class TestBaseService(NIOTestCase):
 
         # verify that statuses were updated
         status = service.full_status()
-        self.assertIn("service", status)
-        self.assertEqual(status["service"], "stopped")
-        self.assertIn("block1", status)
-        self.assertEqual(status["block1"], "stopped")
-        self.assertIn("block2", status)
-        self.assertEqual(status["block2"], "stopped")
+        status_values = list(status.values())
+        self.assertEqual(len(status_values), 3)
+        self.assertEqual(status_values[0], "stopped")
+        self.assertEqual(status_values[1], "stopped")
+        self.assertEqual(status_values[2], "stopped")
 
     def test_start_stop_blocks_async(self):
         """ Makes sure blocks are started/stopped according to 'async' setting
         """
         service = Service()
-
         blocks = [{"type": Block,
-                   "properties": {'name': 'block1'}},
+                   "properties": {}},
                   {"type": Block,
-                   "properties": {'name': 'block2'}}]
-
+                   "properties": {}}]
         service.do_configure(ServiceContext(
             {"name": "ServiceName", "log_level": "WARNING"},
             blocks=blocks,
@@ -104,6 +99,11 @@ class TestBaseService(NIOTestCase):
             # assert one spawn call per block stopped
             self.assertEqual(spawn_patched.call_count, 4)
 
+        service = Service()
+        blocks = [{"type": Block,
+                   "properties": {}},
+                  {"type": Block,
+                   "properties": {}}]
         service.do_configure(ServiceContext(
             {"name": "ServiceName", "log_level": "WARNING"},
             blocks=blocks,
@@ -121,6 +121,11 @@ class TestBaseService(NIOTestCase):
             service.do_stop()
             self.assertEqual(spawn_patched.call_count, 2)
 
+        service = Service()
+        blocks = [{"type": Block,
+                   "properties": {}},
+                  {"type": Block,
+                   "properties": {}}]
         service.do_configure(ServiceContext(
             {"name": "ServiceName", "log_level": "WARNING"},
             blocks=blocks,
@@ -173,7 +178,7 @@ class TestBaseService(NIOTestCase):
         service.do_stop()
 
     def test_config_with_no_name(self):
-        """Make sure a service cononfig has required 'name' property."""
+        """Make sure a service config has required 'name' property."""
         service = Service()
         with self.assertRaises(AllowNoneViolation):
             service.configure(ServiceContext({}))

--- a/nio/testing/block_test_case.py
+++ b/nio/testing/block_test_case.py
@@ -132,8 +132,8 @@ class NIOBlockTestCase(NIOTestCase):
             block_properties (dict): properties to assign
 
         """
-        # Blocks should always have a 'name', but we'll let it pass in tests
-        block_properties["name"] = block_properties.get("name", "default")
+        # Blocks should always have an 'id', but we'll let it pass in tests
+        block_properties["id"] = block_properties.get("id", "default")
         block.configure(BlockContext(
             self._router,
             block_properties,


### PR DESCRIPTION
The idea is to have the framework clean of any backwards compatibility issues, and deal with backwards compatibility in the core, a proof of concept that I tested successfully having the core load old projects while using this framework