### PR TITLE
Move certain base properties to advanced

### DIFF
--- a/nio/block/base.py
+++ b/nio/block/base.py
@@ -28,7 +28,7 @@ class Base(PropertyHolder, CommandHolder, Runner):
     id = StringProperty(title="Id", visible=False, allow_none=False)
     name = StringProperty(title="Name", visible=False, allow_none=True)
     log_level = SelectProperty(enum=LogLevel,
-                               title="Log Level", default="NOTSET")
+                               title="Log Level", default="NOTSET", advanced=True)
 
     def __init__(self, status_change_callback=None):
         """ Create a new block instance.

--- a/nio/block/mixins/collector/collector.py
+++ b/nio/block/mixins/collector/collector.py
@@ -20,7 +20,8 @@ class Collector(object):
     """
 
     collect = TimeDeltaProperty(
-        title='Collect Timeout', default={"seconds": 1})
+        title='Collect Timeout', default={"seconds": 1}, advanced=True
+    )
 
     def __init__(self):
         super().__init__()

--- a/nio/block/mixins/persistence/persistence.py
+++ b/nio/block/mixins/persistence/persistence.py
@@ -16,7 +16,8 @@ class Persistence(object):
     backup_interval = TimeDeltaProperty(
         visible=False, title='Backup Interval', default={"seconds": 60 * 60})
     load_from_persistence = BoolProperty(
-        title='Load from Persistence?', default=True)
+        title='Load from Persistence?', default=True, advanced=True
+    )
 
     def __init__(self):
         super().__init__()

--- a/nio/block/mixins/retry/retry.py
+++ b/nio/block/mixins/retry/retry.py
@@ -87,7 +87,7 @@ class Retry(object):
     """
 
     retry_options = ObjectProperty(RetryOptions, title="Retry Options",
-                                   visible=True, default=RetryOptions())
+                                   advanced=True, default=RetryOptions())
 
     def configure(self, context):
         """ This implementation will use the configured backoff strategy """

--- a/nio/properties/version.py
+++ b/nio/properties/version.py
@@ -22,9 +22,9 @@ class VersionProperty(StringProperty):
                 # hmm, both version and default specified,
                 # version argument overrides
                 kwargs["default"] = version
-            super().__init__(title=title, **kwargs)
+            super().__init__(title=title, advanced=True, **kwargs)
         else:
-            super().__init__(title=title, default=version, **kwargs)
+            super().__init__(title=title, advanced=True, default=version, **kwargs)
 
     def __set__(self, instance, value):
         """ Override default set to make sure it's a valid version """


### PR DESCRIPTION
In part of the move to have advanced properties under an advanced section it was agreed upon (by both scott and tom) to have `log_level` and `version` be advanced properties.

This will make these properties advanced for every block cleaning up the Block Configuration modal greatly!