### PR TITLE
Add order attribute to properties

### DIFF
--- a/nio/block/mixins/collector/collector.py
+++ b/nio/block/mixins/collector/collector.py
@@ -20,7 +20,7 @@ class Collector(object):
     """
 
     collect = TimeDeltaProperty(
-        title='Collect Timeout', default={"seconds": 1}, advanced=True
+        title='Collect Timeout', default={"seconds": 1}, advanced=True, order=100
     )
 
     def __init__(self):

--- a/nio/block/mixins/enrich/enrich_signals.py
+++ b/nio/block/mixins/enrich/enrich_signals.py
@@ -13,7 +13,7 @@ class EnrichProperties(PropertyHolder):
 class EnrichSignals(object):
 
     enrich = ObjectProperty(EnrichProperties, title='Signal Enrichment',
-                            default=EnrichProperties())
+                            default=EnrichProperties(), order=100)
 
     def get_output_signal(self, signal_data, incoming_signal, copy=True):
         """ Get an output signal based on the block configuration.

--- a/nio/block/mixins/group_by/group_by.py
+++ b/nio/block/mixins/group_by/group_by.py
@@ -30,7 +30,7 @@ class GroupBy(CommandHolder):
 
     """
 
-    group_by = Property(title="Group By", default=None, allow_none=True)
+    group_by = Property(title="Group By", default=None, order=100, allow_none=True)
 
     def __init__(self):
         super().__init__()

--- a/nio/block/mixins/persistence/persistence.py
+++ b/nio/block/mixins/persistence/persistence.py
@@ -16,7 +16,7 @@ class Persistence(object):
     backup_interval = TimeDeltaProperty(
         visible=False, title='Backup Interval', default={"seconds": 60 * 60})
     load_from_persistence = BoolProperty(
-        title='Load from Persistence?', default=True, advanced=True
+        title='Load from Persistence?', default=True, advanced=True, order=100
     )
 
     def __init__(self):

--- a/nio/block/mixins/retry/retry.py
+++ b/nio/block/mixins/retry/retry.py
@@ -87,7 +87,7 @@ class Retry(object):
     """
 
     retry_options = ObjectProperty(RetryOptions, title="Retry Options",
-                                   advanced=True, default=RetryOptions())
+                                   advanced=True, order=100, default=RetryOptions())
 
     def configure(self, context):
         """ This implementation will use the configured backoff strategy """

--- a/nio/properties/base.py
+++ b/nio/properties/base.py
@@ -18,8 +18,8 @@ class BaseProperty(object):
         description (dict): Property settings.
     """
 
-    def __init__(self, _type, title=None,
-                 advanced=False, visible=True, allow_none=False, default=None, **kwargs):
+    def __init__(self, _type, title=None, advanced=False, visible=True, 
+                    order=None, allow_none=False, default=None, **kwargs):
         self.type = _type
 
         # make sure title is valid
@@ -27,6 +27,11 @@ class BaseProperty(object):
             self.title = title
         else:
             raise ValueError("Title must be a non-empty string")
+
+        if isinstance(order, int) or order is None:
+            self.order = order
+        else:
+            raise ValueError("Order must be an integer")
 
         self.advanced = advanced
         self.visible = visible
@@ -47,6 +52,7 @@ class BaseProperty(object):
         self.description = dict(type=_type.__name__,
                                 title=title,
                                 advanced=advanced,
+                                order=order,
                                 visible=visible,
                                 allow_none=allow_none,
                                 default=default,

--- a/nio/properties/tests/test_order.py
+++ b/nio/properties/tests/test_order.py
@@ -1,0 +1,17 @@
+
+from nio.properties import BaseProperty
+from nio.types import Type
+from nio.testing.test_case import NIOTestCaseNoModules
+
+
+class TestOrder(NIOTestCaseNoModules):
+
+    def test_order(self):
+        with self.assertRaises(ValueError):
+            BaseProperty(Type, title="title", order="str")
+
+        with self.assertRaises(ValueError):
+            BaseProperty(Type, title="title", order=2.1)
+
+        property = BaseProperty(Type, title="title", order=12)
+        self.assertEqual(property.order, 12)

--- a/nio/properties/tests/test_property_holder.py
+++ b/nio/properties/tests/test_property_holder.py
@@ -139,6 +139,7 @@ class TestPropertyHolder(NIOTestCaseNoModules):
         # check mandatory settings
         self.assertIn('title', description['property'])
         self.assertIn('advanced', description['property'])
+        self.assertIn('order', description['property'])
         self.assertIn('visible', description['property'])
         self.assertIn('allow_none', description['property'])
         self.assertIn('default', description['property'])


### PR DESCRIPTION
Adds an `order` attribute to all properties, default to `null`
Added validation for order to be only int or null
Added default order of `100` to all mixins