### PR TITLE
Add set_status method in block base

### DIFF
--- a/nio/block/base.py
+++ b/nio/block/base.py
@@ -155,6 +155,8 @@ class Base(PropertyHolder, CommandHolder, Runner):
                 # Default to a created status if the block has no statues left
                 status = RunnerStatus.created
                 for flag, flag_set in self.status.flags.items():
+                    if flag in ('warning', 'error'):
+                        continue
                     if flag_set:
                         status = RunnerStatus[flag]
                         break

--- a/nio/block/base.py
+++ b/nio/block/base.py
@@ -15,7 +15,7 @@ from nio.signal.base import Signal
 from nio.signal.status import BlockStatusSignal
 from nio.util.logging import get_nio_logger
 from nio.util.logging.levels import LogLevel
-from nio.util.runner import Runner
+from nio.util.runner import Runner, RunnerStatus
 
 
 @command('properties')
@@ -111,6 +111,76 @@ class Base(PropertyHolder, CommandHolder, Runner):
         in the service process.
         """
         pass  # pragma: no cover
+
+    def set_status(self, status, message=""):
+        """ Set this block's status and notify the management channel.
+
+        This is a method that a block developer can use to set their block's
+        status. A block in warning or error status may be noted in the
+        system designer or in monitoring tools.
+
+        In general a block in warning status has a problematic condition but
+        may be able to recover on its own (e.g., retrying a connection). A
+        block in error status is in a state that will require a human to
+        resolve the error; either by fixing the error condition or restarting
+        the service.
+
+        Note: By specifying a string based status the status will be added to
+        as opposed to replaced. In other words, if your block is in a status
+        of 'started' and you call `self.set_status('error')` the new block
+        status will be 'started, error'. If instead you call 
+        `self.set_status(RunnerStatus.error)` the new block status will be
+        'error' only.
+
+        Args:
+            status (str or RunnerStatus): A nio.util.runner.RunnerStatus to
+                set the block's statut to. Optionally takes a string if the
+                string is one of (error, warning, ok). Specifying 'error' or
+                'warning' will set those status flags on the block. Specifying
+                'ok' as a status string will clear both error and warning
+                status flags.
+            message (str): An optional string message to include in the
+                notification of the status change.
+
+        Returns:
+            RunnerStatus: The current block's status after setting.
+
+        Raises:
+            ValueError: If a string other than "ok", "warning", or "error" is
+                provided as the status
+            TypeError: If an invalid status type or message type is specified
+        """
+        if isinstance(status, str):
+            if status.lower() == 'ok':
+                self.status.remove(RunnerStatus.error)
+                self.status.remove(RunnerStatus.warning)
+                status_to_notify = self.status
+            elif status.lower() == 'warn' or status.lower() == 'warning':
+                self.status.remove(RunnerStatus.error)
+                self.status.add(RunnerStatus.warning)
+                status_to_notify = RunnerStatus.warning
+            elif status.lower() == 'error':
+                self.status.remove(RunnerStatus.warning)
+                self.status.add(RunnerStatus.error)
+                status_to_notify = RunnerStatus.error
+            else:
+                raise ValueError("Only 'ok', 'warning', or 'error' are "
+                                 "supported status strings")
+        elif isinstance(status, RunnerStatus):
+            self.status.set(status)
+            status_to_notify = status
+        else:
+            raise TypeError(
+                "Block status can only be set to string or RunnerStatus")
+
+        if not isinstance(message, str):
+            raise TypeError("Only string based status messages are allowed")
+
+        # Notify the new status to the management channel for other services
+        # to handle
+        signal = BlockStatusSignal(status_to_notify, message=message)
+        self.notify_management_signal(signal)
+        return self.status
 
     def notify_signals(self, signals, output_id=None):
         """Notify signals to router.

--- a/nio/block/tests/test_block_base.py
+++ b/nio/block/tests/test_block_base.py
@@ -148,9 +148,8 @@ class TestBaseBlock(NIOTestCaseNoModules):
         mgmt_sig = mgmt_signal_handler.call_args[0][0]
         self.assertEqual(mgmt_sig.status, RunnerStatus.warning)
 
-        # Setting the error status should keep the original status, clear the
-        # warning status, and add the error status
-        blk.set_status('error')
+        # Try with a RunnerStatus this time
+        blk.set_status(RunnerStatus.error)
         self.assertTrue(blk.status.is_set(RunnerStatus.configured))
         self.assertFalse(blk.status.is_set(RunnerStatus.warning))
         self.assertTrue(blk.status.is_set(RunnerStatus.error))
@@ -169,6 +168,11 @@ class TestBaseBlock(NIOTestCaseNoModules):
         mgmt_sig = mgmt_signal_handler.call_args[0][0]
         self.assertEqual(mgmt_sig.status, RunnerStatus.configured)
 
+        # Make sure we default to a created status if the block has no status
+        blk.status.clear()
+        blk.set_status('ok')
+        self.assertTrue(blk.status.is_set(RunnerStatus.created))
+
     def test_replace_status_with_helper(self):
         """ Test that the block replaces status if a RunnerStatus is given """
         mgmt_signal_handler = Mock()
@@ -183,7 +187,7 @@ class TestBaseBlock(NIOTestCaseNoModules):
         self.assertFalse(blk.status.is_set(RunnerStatus.error))
         self.assertEqual(mgmt_signal_handler.call_count, 0)
         # Setting warning status should replace the original status
-        blk.set_status(RunnerStatus.warning)
+        blk.set_status('warning', replace_existing=True)
         self.assertFalse(blk.status.is_set(RunnerStatus.configured))
         self.assertTrue(blk.status.is_set(RunnerStatus.warning))
         self.assertFalse(blk.status.is_set(RunnerStatus.error))
@@ -195,7 +199,7 @@ class TestBaseBlock(NIOTestCaseNoModules):
 
         # Setting the error status should keep the original status, clear the
         # warning status, and add the error status
-        blk.set_status(RunnerStatus.error)
+        blk.set_status(RunnerStatus.error, replace_existing=True)
         self.assertFalse(blk.status.is_set(RunnerStatus.configured))
         self.assertFalse(blk.status.is_set(RunnerStatus.warning))
         self.assertTrue(blk.status.is_set(RunnerStatus.error))
@@ -206,7 +210,7 @@ class TestBaseBlock(NIOTestCaseNoModules):
         self.assertEqual(mgmt_sig.status, RunnerStatus.error)
 
         # "reset" the status by passing a valid RunnerStatus
-        blk.set_status(RunnerStatus.started)
+        blk.set_status(RunnerStatus.started, replace_existing=True)
         self.assertFalse(blk.status.is_set(RunnerStatus.configured))
         self.assertFalse(blk.status.is_set(RunnerStatus.warning))
         self.assertFalse(blk.status.is_set(RunnerStatus.error))


### PR DESCRIPTION
This provides the option for a block developer to use a "shortcut" helper method to set their block's status. There are two ways to use the method, the first would be preferred/used more often.

Option 1: String based statuses
Pass the "status" of your block as a string. Prevents having to import RunnerStatus and to worry about clearing/not clearing old statuses. Only `ok`, `warning`/`warn`, and `error` are valid status strings.
```python
self.set_status('warning')
self.set_status('error', 'I can include messages too')
self.set_status('ok', 'Back to normal!')
```

Option 2: RunnerStatus statuses
This requires you pass a RunnerStatus and it replaces the status of the block entirely.
```python
self.set_status(RunnerStatus.warning)
self.set_status(RunnerStatus.error)
self.set_status(Runner.started)
```
This is essentially equivalent to calling `self.status = RunnerStatus.error` except that it also sends the management signal for you.