### PR TITLE
NIO-1125, adding block messages

### DIFF
--- a/nio/block/base.py
+++ b/nio/block/base.py
@@ -3,6 +3,8 @@
 A block contains modular functionality to be used inside of Services. To create
 a custom block, extend this Block class and override the appropriate methods.
 """
+from collections import defaultdict
+
 from nio.block.context import BlockContext
 from nio.block.terminals import Terminal, TerminalType, input, output, \
     DEFAULT_TERMINAL
@@ -59,6 +61,7 @@ class Base(PropertyHolder, CommandHolder, Runner):
             self.__class__, TerminalType.input)
         self._default_output = Terminal.get_default_terminal_on_class(
             self.__class__, TerminalType.output)
+        self._messages = defaultdict(str)
 
     def configure(self, context):
         """Overrideable method to be called when the block configures.
@@ -177,8 +180,17 @@ class Base(PropertyHolder, CommandHolder, Runner):
         # Clear old error/warn status if a non-error/warn status is passed
         if status != RunnerStatus.error:
             self.status.remove(RunnerStatus.error)
+            if RunnerStatus.error in self._messages:
+                del self._messages[RunnerStatus.error]
+        else:
+            self._messages[RunnerStatus.error] = message
+
         if status != RunnerStatus.warning:
             self.status.remove(RunnerStatus.warning)
+            if RunnerStatus.warning in self._messages:
+                del self._messages[RunnerStatus.warning]
+        else:
+            self._messages[RunnerStatus.warning] = message
 
         if replace_existing:
             self.status.set(status)

--- a/nio/service/base.py
+++ b/nio/service/base.py
@@ -283,8 +283,16 @@ class Service(PropertyHolder, CommandHolder, Runner):
         # create a dict for all blocks using block label as key
         blocks = {}
         for block_id in self._blocks:
-            blocks[self._blocks[block_id].label()] = \
-                self._blocks[block_id].status.name
+            block_status = {"status": self._blocks[block_id].status.name}
+            if self._blocks[block_id].status.is_set(RunnerStatus.warning):
+                block_status["warning"] = \
+                    self._blocks[block_id]._messages[RunnerStatus.warning]
+            if self._blocks[block_id].status.is_set(RunnerStatus.error):
+                block_status["error"] = \
+                    self._blocks[block_id]._messages[RunnerStatus.error]
+
+            blocks[self._blocks[block_id].label()] = block_status
+
         status["blocks"] = blocks
         return status
 

--- a/nio/service/tests/test_service_base.py
+++ b/nio/service/tests/test_service_base.py
@@ -52,8 +52,8 @@ class TestBaseService(NIOTestCase):
         self.assertEqual(status["service"], "configured")
         self.assertEqual(status["service_and_blocks"], "configured")
         self.assertEqual(len(status["blocks"]), 2)
-        self.assertEqual(status["blocks"]["block1"], "configured")
-        self.assertEqual(status["blocks"]["block2"], "configured")
+        self.assertEqual(status["blocks"]["block1"]["status"], "configured")
+        self.assertEqual(status["blocks"]["block2"]["status"], "configured")
 
         service.do_start()
         # verify that statuses were updated
@@ -63,8 +63,8 @@ class TestBaseService(NIOTestCase):
         self.assertEqual(status["service"], "started")
         self.assertEqual(status["service_and_blocks"], "started")
         self.assertEqual(len(status["blocks"]), 2)
-        self.assertEqual(status["blocks"]["block1"], "started")
-        self.assertEqual(status["blocks"]["block2"], "started")
+        self.assertEqual(status["blocks"]["block1"]["status"], "started")
+        self.assertEqual(status["blocks"]["block2"]["status"], "started")
 
         self.assertEqual(len(service.blocks), 2)
 
@@ -77,8 +77,22 @@ class TestBaseService(NIOTestCase):
         self.assertEqual(status["service"], "stopped")
         self.assertEqual(status["service_and_blocks"], "stopped")
         self.assertEqual(len(status["blocks"]), 2)
-        self.assertEqual(status["blocks"]["block1"], "stopped")
-        self.assertEqual(status["blocks"]["block2"], "stopped")
+        self.assertEqual(status["blocks"]["block1"]["status"], "stopped")
+        self.assertEqual(status["blocks"]["block2"]["status"], "stopped")
+
+        # simulate a warning status
+        service.blocks["block1"].set_status('warning', "a warning msg")
+
+        status = service.full_status()
+        self.assertEqual(status["service"], "stopped")
+        self.assertIn("warning", status["service_and_blocks"])
+        self.assertIn("stopped", status["service_and_blocks"])
+        self.assertEqual(len(status["blocks"]), 2)
+        # assert block1 statuses
+        self.assertIn("warning", status["blocks"]["block1"]["status"])
+        self.assertIn("stopped", status["blocks"]["block1"]["status"])
+        self.assertEqual(status["blocks"]["block1"]["warning"], "a warning msg")
+        self.assertEqual(status["blocks"]["block2"]["status"], "stopped")
 
     def test_blocks_async(self):
         """ Makes sure blocks are started/stopped according to 'async' setting


### PR DESCRIPTION
@mattdodge I changed the implementation to match the results you expected in the first place
```
{
    "status": "started, warning",
    "pid": 98403,
    "parent_pid": 98397,
    "full_status": {
        "service": "started",
        "blocks": {
            "my_logger": {
                "status": "started"
            },
            "my_sub": {
                "status": "started, warning",
                "warning": "Block is not connected"
            },
            "my_pub": {
                "status": "started, warning",
                "warning": "Block is not connected"
            },
            "ee49544c-cdf7-48ad-9780-2ae9653c8d23": {
                "status": "started"
            }
        }
    }
}
```
the only thing I find with this approach is that calling API would have to "parse" to find out if a message is returned, is that too weird? (Note: I have a different branch with a different implementation, it is more elaborate and returns a more verbose result...)