### PR TITLE
check for allow_none before deserializing

### DIFF
--- a/nio/properties/holder.py
+++ b/nio/properties/holder.py
@@ -41,7 +41,6 @@ class PropertyHolder(object):
             ignore_none (bool): if True, properties that have a value equal to
                 None are ignored (useful when wanting to validate errors on
                 properties for which a value other than None has been assigned)
-
         Raises:
             AllowNoneViolation: Property value does not allow none, available
                 when ignore_none is False
@@ -52,7 +51,8 @@ class PropertyHolder(object):
         for (property_name, prop) in class_properties.items():
             # Deserialize the raw value of the PropertyValue
             value = getattr(self, property_name).value
-            if value is None and ignore_none:
+            if value is None and (ignore_none or \
+                                  getattr(prop, 'allow_none', False)):
                 continue
             # Deserialize to check for AllowNoneViolation and TypeError
             prop.deserialize(value)

--- a/nio/properties/holder.py
+++ b/nio/properties/holder.py
@@ -41,6 +41,7 @@ class PropertyHolder(object):
             ignore_none (bool): if True, properties that have a value equal to
                 None are ignored (useful when wanting to validate errors on
                 properties for which a value other than None has been assigned)
+
         Raises:
             AllowNoneViolation: Property value does not allow none, available
                 when ignore_none is False

--- a/nio/properties/holder.py
+++ b/nio/properties/holder.py
@@ -51,8 +51,7 @@ class PropertyHolder(object):
         for (property_name, prop) in class_properties.items():
             # Deserialize the raw value of the PropertyValue
             value = getattr(self, property_name).value
-            if value is None and (ignore_none or \
-                                  getattr(prop, 'allow_none', False)):
+            if value is None and ignore_none:
                 continue
             # Deserialize to check for AllowNoneViolation and TypeError
             prop.deserialize(value)

--- a/nio/types/float.py
+++ b/nio/types/float.py
@@ -13,7 +13,7 @@ class FloatType(Type):
         """ Convert value to float """
         try:
             return float(value)
-        except TypeError:
+        except (TypeError, ValueError):
             if value is None:
                 # allow_none has already been checked and None 
                 # is a valid value for a FloatType

--- a/nio/types/float.py
+++ b/nio/types/float.py
@@ -14,4 +14,8 @@ class FloatType(Type):
         try:
             return float(value)
         except:
+            if value is None:
+                # allow_none has already been checked and None 
+                # is a valid value for a FloatType
+                return None
             raise TypeError("Unable to cast value to float: {}".format(value))

--- a/nio/types/float.py
+++ b/nio/types/float.py
@@ -13,7 +13,7 @@ class FloatType(Type):
         """ Convert value to float """
         try:
             return float(value)
-        except:
+        except TypeError:
             if value is None:
                 # allow_none has already been checked and None 
                 # is a valid value for a FloatType

--- a/nio/types/int.py
+++ b/nio/types/int.py
@@ -13,7 +13,7 @@ class IntType(Type):
         """ Convert value to int """
         try:
             return int(value)
-        except:
+        except TypeError:
             if value is None:
                 # allow_none has already been checked and None 
                 # is a valid value for an IntType

--- a/nio/types/int.py
+++ b/nio/types/int.py
@@ -14,4 +14,8 @@ class IntType(Type):
         try:
             return int(value)
         except:
+            if value is None:
+                # allow_none has already been checked and None 
+                # is a valid value for an IntType
+                return None
             raise TypeError("Unable to cast value to an int: {}".format(value))

--- a/nio/types/int.py
+++ b/nio/types/int.py
@@ -13,7 +13,7 @@ class IntType(Type):
         """ Convert value to int """
         try:
             return int(value)
-        except TypeError:
+        except (TypeError, ValueError):
             if value is None:
                 # allow_none has already been checked and None 
                 # is a valid value for an IntType

--- a/nio/types/tests/test_types.py
+++ b/nio/types/tests/test_types.py
@@ -73,7 +73,7 @@ class TestTypes(NIOTestCase):
                     type_.deserialize(value)
 
     def test_allowed_none_values(self):
-        """Int and Float Properties are able to evaluate to None if allowed"""
+        """Int and Float Types are able to evaluate to None if allowed"""
         none_int = IntType.deserialize(None)
         none_float = FloatType.deserialize(None)
 

--- a/nio/types/tests/test_types.py
+++ b/nio/types/tests/test_types.py
@@ -72,6 +72,11 @@ class TestTypes(NIOTestCase):
                 with self.assertRaises(TypeError):
                     type_.deserialize(value)
 
+    def test_allowed_none_values(self):
+        """Int and Float Properties are able to evaluate to None if allowed"""
+        none_int = IntType.deserialize(None)
+        none_float = FloatType.deserialize(None)
+
     def test_serialize_deserialize_enum_type(self):
         """serialize then deserialize returns input value for enum type."""
         type_ = SelectType


### PR DESCRIPTION
I created an `IntProperty` with `allow_none=True`, and when testing a `None` value in my block unit test the following was raised:
```
ERROR: test_process_signals (blocks.bacnet.tests.test_read_property_block.TestReadProperty)
A ReadProperty request is sent for every signal processed.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "c:\users\tom\nio\nio\nio\types\int.py", line 15, in deserialize
    return int(value)
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "c:\users\tom\appdata\local\programs\python\python36\lib\unittest\mock.py", line 1179, in patched
    return func(*args, **keywargs)
  File "C:\Users\Tom\nio\projects\bacnet\blocks\bacnet\tests\test_read_property_block.py", line 49, in test_process
_signals
    self.configure_block(blk, config)
  File "c:\users\tom\nio\nio\nio\testing\block_test_case.py", line 127, in configure_block
    mgmt_signal_handler=self.management_signal_notified))
  File "c:\users\tom\nio\nio\nio\block\base.py", line 92, in configure
    self.validate()
  File "c:\users\tom\nio\nio\nio\properties\holder.py", line 58, in validate
    prop.deserialize(value)
  File "c:\users\tom\nio\nio\nio\properties\base.py", line 153, in deserialize
    return self.type.deserialize(value, **merged_kwargs)
  File "c:\users\tom\nio\nio\nio\types\int.py", line 17, in deserialize
    raise TypeError("Unable to cast value to an int: {}".format(value))
TypeError: Unable to cast value to an int: None
```