### PR TITLE
Don't notify empty signal lists

### DIFF
--- a/nio/block/base.py
+++ b/nio/block/base.py
@@ -207,7 +207,8 @@ class Base(PropertyHolder, CommandHolder, Runner):
         """Notify signals to router.
 
         This is the method the block should call whenever it would like
-        to "output" signals for the router to send downstream.
+        to "output" signals for the router to send downstream. Empty signal
+        lists are safely/silently ignored.
 
         Args:
             signals (list): A list of signals to notify to the router
@@ -222,9 +223,12 @@ class Base(PropertyHolder, CommandHolder, Runner):
         Raises:
             TypeError: when signals are not instances of class Signal
         """
-
         if isinstance(signals, dict):
             raise TypeError("Signals cannot be a dictionary")
+
+        if not signals:
+            self.logger.debug("Ignoring empty signal list")
+            return
 
         # if a single Signal is being notified, make it a list
         if isinstance(signals, Signal):

--- a/nio/block/tests/test_block_base.py
+++ b/nio/block/tests/test_block_base.py
@@ -124,6 +124,15 @@ class TestBaseBlock(NIOTestCaseNoModules):
         with self.assertRaises(TypeError):
             blk.notify_signals(dict_signal, "default")
 
+    def test_notify_empty_list(self):
+        """Make sure empty lists notified are ignored"""
+        blk = Block()
+        blk.do_configure(BlockContext(BlockRouter(), {"id": "BlockId"},))
+
+        with patch.object(blk, '_block_router') as router_patch:
+            blk.notify_signals([])
+            self.assertEqual(router_patch.notify_signals.call_count, 0)
+
     def test_add_to_status_with_helper(self):
         """ Test the block adds to its status with the helper method """
         mgmt_signal_handler = Mock()


### PR DESCRIPTION
This PR removes support for notifying empty signal lists. More specifically, it allows blocks to notify empty lists but it won't actually send that empty list to the next block.

The idea behind this is that it will simplify some block code and prevent having to check if signals exist every time before notifying. The downside is it removes the ability to "trigger" another block with an empty list rather than a signal. I think this tradeoff is acceptable though since signals are the real messages being sent, not empty lists.