### PR TITLE
Use the block's actual default output in block tests

### DIFF
--- a/nio/testing/block_test_case.py
+++ b/nio/testing/block_test_case.py
@@ -47,7 +47,7 @@ class BlockRouterForTesting(BlockRouter):
 
         """
         if output_id is None:
-            output_id = DEFAULT_TERMINAL
+            output_id = block._default_output.id
 
         self._block_signal_counts[block] = \
             self._block_signal_counts.get(block) or defaultdict(int)


### PR DESCRIPTION
Before this change, notifying signals without any output ID in a block test would send it to the `DEFAULT_TERMINAL` output rather than the actual default set by the block. This uses the block's real output so you can assert against outputs as expected.