### PR TITLE
fix depreciated import statement

### DIFF
--- a/nio/router/base.py
+++ b/nio/router/base.py
@@ -1,6 +1,6 @@
 import inspect
 
-from collections import Iterable
+from collections.abc import Iterable
 from copy import deepcopy
 
 from nio.router.diagnostic import DiagnosticManager


### PR DESCRIPTION
fix an error caused by using a depreciated import statement in python 3.10 mentioned in #161 